### PR TITLE
Create bringup package

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "micro_ros_agent"]
+	path = micro_ros_agent
+	url = https://github.com/micro-ROS/micro-ROS-Agent.git
+	branch = humble

--- a/micro_ros_platform_firmware/platform/encoder_utils.cpp
+++ b/micro_ros_platform_firmware/platform/encoder_utils.cpp
@@ -12,7 +12,8 @@ float current_front_left_rads_sec = 0;
 float current_front_right_rads_sec = 0;
 unsigned long lastEncoderSampleTime = 0;
 
-void sample_encoders() {
+void sample_encoders()
+{
   unsigned long now = millis();
   long currentFL = frontLeftEncoder.read();
   long currentFR = frontRightEncoder.read();
@@ -23,16 +24,15 @@ void sample_encoders() {
   float flTicksSec = deltaFL / ((now - lastEncoderSampleTime) / 1000.0);
   float frTicksSec = deltaFR / ((now - lastEncoderSampleTime) / 1000.0);
 
-  current_front_left_rads_sec =
-      (flTicksSec / (PULSES_PER_REVOLUTION * GEAR_RATIO_MULTIPLIER)) * -1;
-  current_front_right_rads_sec =
-      frTicksSec / (PULSES_PER_REVOLUTION * GEAR_RATIO_MULTIPLIER);
+  current_front_left_rads_sec = (flTicksSec / (PULSES_PER_REVOLUTION * GEAR_RATIO_MULTIPLIER)) * -1;
+  current_front_right_rads_sec = frTicksSec / (PULSES_PER_REVOLUTION * GEAR_RATIO_MULTIPLIER);
 
   frontLeftLastTicks = currentFL;
   frontRightLastTicks = currentFR;
   lastEncoderSampleTime = now;
 
-  if (SERIAL_DEBUG) {
+  if (SERIAL_DEBUG)
+  {
     Serial1.print("FL: ");
     Serial1.print(current_front_left_rads_sec);
     Serial1.print(" rad/s, FR: ");

--- a/micro_ros_platform_firmware/platform/error_handling.cpp
+++ b/micro_ros_platform_firmware/platform/error_handling.cpp
@@ -1,7 +1,9 @@
 #include "error_handling.hpp"
 
-void error_loop() {
-  while (1) {
+void error_loop()
+{
+  while (1)
+  {
     digitalWrite(LED_PIN, !digitalRead(LED_PIN));
     delay(100);
   }

--- a/micro_ros_platform_firmware/platform/error_handling.hpp
+++ b/micro_ros_platform_firmware/platform/error_handling.hpp
@@ -7,19 +7,21 @@
 void error_loop();
 
 // Macro helpers for micro-ROS error handling
-#define RCCHECK(fn)                                                            \
-  {                                                                            \
-    rcl_ret_t temp_rc = fn;                                                    \
-    if ((temp_rc != RCL_RET_OK)) {                                             \
-      Serial1.println("Hard error!");                                          \
-      error_loop();                                                            \
-    }                                                                          \
+#define RCCHECK(fn)                                                                                \
+  {                                                                                                \
+    rcl_ret_t temp_rc = fn;                                                                        \
+    if ((temp_rc != RCL_RET_OK))                                                                   \
+    {                                                                                              \
+      Serial1.println("Hard error!");                                                              \
+      error_loop();                                                                                \
+    }                                                                                              \
   }
-#define RCSOFTCHECK(fn)                                                        \
-  {                                                                            \
-    rcl_ret_t temp_rc = fn;                                                    \
-    if ((temp_rc != RCL_RET_OK)) {                                             \
-      Serial1.print("Soft error: ");                                           \
-      Serial1.println(temp_rc);                                                \
-    }                                                                          \
+#define RCSOFTCHECK(fn)                                                                            \
+  {                                                                                                \
+    rcl_ret_t temp_rc = fn;                                                                        \
+    if ((temp_rc != RCL_RET_OK))                                                                   \
+    {                                                                                              \
+      Serial1.print("Soft error: ");                                                               \
+      Serial1.println(temp_rc);                                                                    \
+    }                                                                                              \
   }

--- a/micro_ros_platform_firmware/platform/motor_control.cpp
+++ b/micro_ros_platform_firmware/platform/motor_control.cpp
@@ -16,7 +16,8 @@ QuickPID front_left_pid(&current_front_left_rads_sec, &front_left_output,
 /**
  * @brief Function to setup the PID controllers
  */
-void setup_pid() {
+void setup_pid()
+{
   front_left_pid.SetOutputLimits(-127.0, 127.0);
   front_left_pid.SetTunings(3.0, 0.0, 0.00);
   front_left_pid.SetSampleTimeUs(100000);
@@ -34,8 +35,8 @@ void setup_pid() {
  * @param motor The motor number (1 or 2).
  * @param speed The speed value to set for the motor (-127 to 127).
  */
-void send_sabertooth_command(HardwareSerial &port, byte address, byte motor,
-                             int speed) {
+void send_sabertooth_command(HardwareSerial& port, byte address, byte motor, int speed)
+{
 
   //  Constrain the speed to the valid range
   speed = constrain(speed, -127, 127);
@@ -62,17 +63,18 @@ void send_sabertooth_command(HardwareSerial &port, byte address, byte motor,
 /**
  * @brief Function to update the motors based on the PID output.
  */
-void update_motors() {
+void update_motors()
+{
 
   //  Compute the PID output for the front left motor
   front_left_pid.Compute();
 
-  if (SERIAL_DEBUG) {
+  if (SERIAL_DEBUG)
+  {
     Serial1.print("Front Left PID Output: ");
     Serial1.println(front_left_output);
   }
 
   //  Send the command to the Sabertooth motor driver for the front left motor
-  send_sabertooth_command(Serial2, SABERTOOTH_ADDR, 1,
-                          front_left_velocity_setpoint * 4);
+  send_sabertooth_command(Serial2, SABERTOOTH_ADDR, 1, front_left_velocity_setpoint * 4);
 }

--- a/micro_ros_platform_firmware/platform/motor_control.hpp
+++ b/micro_ros_platform_firmware/platform/motor_control.hpp
@@ -22,6 +22,5 @@ extern float current_front_left_rads_sec;
 extern float current_front_right_rads_sec;
 
 void setup_pid();
-void send_sabertooth_command(HardwareSerial &port, byte address, byte motor,
-                             int speed);
+void send_sabertooth_command(HardwareSerial& port, byte address, byte motor, int speed);
 void update_motors();

--- a/micro_ros_platform_firmware/platform/msg_utils.cpp
+++ b/micro_ros_platform_firmware/platform/msg_utils.cpp
@@ -11,7 +11,8 @@ rosidl_runtime_c__String name_data[MAX_JOINTS];
 char name_buffer[MAX_JOINTS][MAX_NAME_LEN];
 double velocity_data[MAX_JOINTS];
 
-void initialise_joint_state_message(sensor_msgs__msg__JointState &msg) {
+void initialise_joint_state_message(sensor_msgs__msg__JointState& msg)
+{
   msg.name.data = name_data;
   msg.name.size = 2;
   msg.name.capacity = MAX_JOINTS;
@@ -28,11 +29,11 @@ void initialise_joint_state_message(sensor_msgs__msg__JointState &msg) {
   msg.effort.size = 0;
   msg.effort.capacity = 0;
 
-  name_data[0].data = (char *)"left_front_wheel_joint";
+  name_data[0].data = (char*) "left_front_wheel_joint";
   name_data[0].size = strlen(name_data[0].data);
   name_data[0].capacity = MAX_NAME_LEN;
 
-  name_data[1].data = (char *)"right_front_wheel_joint";
+  name_data[1].data = (char*) "right_front_wheel_joint";
   name_data[1].size = strlen(name_data[1].data);
   name_data[1].capacity = MAX_NAME_LEN;
 
@@ -45,17 +46,19 @@ void initialise_joint_state_message(sensor_msgs__msg__JointState &msg) {
   // name_data[3].capacity = MAX_NAME_LEN;
 }
 
-void publish_joint_state_message() {
+void publish_joint_state_message()
+{
   feedback_msg.velocity.data[0] = current_front_left_rads_sec;
   feedback_msg.velocity.data[1] = current_front_right_rads_sec;
   RCSOFTCHECK(rcl_publish(&feedback_publisher, &feedback_msg, NULL));
 }
 
-void subscription_callback(const void *msgin) {
-  const sensor_msgs__msg__JointState *joint_msg =
-      (const sensor_msgs__msg__JointState *)msgin;
-  for (size_t i = 0; i < joint_msg->name.size && i < MAX_JOINTS; i++) {
-    const char *name = joint_msg->name.data[i].data;
+void subscription_callback(const void* msgin)
+{
+  const sensor_msgs__msg__JointState* joint_msg = (const sensor_msgs__msg__JointState*) msgin;
+  for (size_t i = 0; i < joint_msg->name.size && i < MAX_JOINTS; i++)
+  {
+    const char* name = joint_msg->name.data[i].data;
     float velocity = joint_msg->velocity.data[i];
     if (strcmp(name, "left_front_wheel_joint") == 0)
       front_left_velocity_setpoint = velocity;

--- a/micro_ros_platform_firmware/platform/msg_utils.hpp
+++ b/micro_ros_platform_firmware/platform/msg_utils.hpp
@@ -5,6 +5,6 @@
 #define MAX_JOINTS 2
 #define MAX_NAME_LEN 25
 
-void initialise_joint_state_message(sensor_msgs__msg__JointState &msg);
+void initialise_joint_state_message(sensor_msgs__msg__JointState& msg);
 void publish_joint_state_message();
-void subscription_callback(const void *msgin);
+void subscription_callback(const void* msgin);

--- a/micro_ros_platform_firmware/platform/ros_interface.cpp
+++ b/micro_ros_platform_firmware/platform/ros_interface.cpp
@@ -17,7 +17,8 @@ rcl_node_t node;
 sensor_msgs__msg__JointState cmd_msg;
 sensor_msgs__msg__JointState feedback_msg;
 
-void ros_setup() {
+void ros_setup()
+{
   // Serial setup
   Serial2.begin(9600); // Sabertooth
   if (SERIAL_DEBUG)
@@ -34,8 +35,7 @@ void ros_setup() {
   // ROS node and entities
   allocator = rcl_get_default_allocator();
   RCCHECK(rclc_support_init(&support, 0, NULL, &allocator));
-  RCCHECK(
-      rclc_node_init_default(&node, "micro_ros_platform_node", "", &support));
+  RCCHECK(rclc_node_init_default(&node, "micro_ros_platform_node", "", &support));
 
   rcutils_logging_set_default_logger_level(RCUTILS_LOG_SEVERITY_DEBUG);
 
@@ -44,27 +44,27 @@ void ros_setup() {
   initialise_joint_state_message(cmd_msg);
   initialise_joint_state_message(feedback_msg);
 
-  const rosidl_message_type_support_t *type_support =
+  const rosidl_message_type_support_t* type_support =
       ROSIDL_GET_MSG_TYPE_SUPPORT(sensor_msgs, msg, JointState);
 
   rcl_subscription_options_t sub_ops = rcl_subscription_get_default_options();
   sub_ops.qos = rmw_qos_profile_sensor_data;
 
-  RCCHECK(rcl_subscription_init(&joint_state_subscriber, &node, type_support,
-                                "platform/motors/cmd", &sub_ops));
+  RCCHECK(rcl_subscription_init(&joint_state_subscriber, &node, type_support, "platform/motors/cmd",
+                                &sub_ops));
 
   rcl_publisher_options_t pub_ops = rcl_publisher_get_default_options();
   pub_ops.qos = rmw_qos_profile_sensor_data;
 
-  RCCHECK(rcl_publisher_init(&feedback_publisher, &node, type_support,
-                             "platform/motors/feedback", &pub_ops));
+  RCCHECK(rcl_publisher_init(&feedback_publisher, &node, type_support, "platform/motors/feedback",
+                             &pub_ops));
 
   RCCHECK(rclc_executor_init(&executor, &support.context, 1, &allocator));
-  RCCHECK(rclc_executor_add_subscription(&executor, &joint_state_subscriber,
-                                         &cmd_msg, &subscription_callback,
-                                         ON_NEW_DATA));
+  RCCHECK(rclc_executor_add_subscription(&executor, &joint_state_subscriber, &cmd_msg,
+                                         &subscription_callback, ON_NEW_DATA));
 }
 
-void spin_ros_executor() {
+void spin_ros_executor()
+{
   RCSOFTCHECK(rclc_executor_spin_some(&executor, RCL_MS_TO_NS(100)));
 }

--- a/rugged_rover_bringup/CMakeLists.txt
+++ b/rugged_rover_bringup/CMakeLists.txt
@@ -11,9 +11,14 @@ find_package(rclcpp REQUIRED)
 find_package(controller_manager REQUIRED)
 find_package(ros2_control REQUIRED)
 find_package(robot_state_publisher REQUIRED)
-find_package(rugged_rover_description REQUIRED)
+find_package(rugged_rover_robot_description REQUIRED)
 find_package(rugged_rover_control REQUIRED)
 find_package(rugged_rover_hardware_interfaces REQUIRED)
+
+install(DIRECTORY
+  launch
+  DESTINATION share/${PROJECT_NAME}/
+)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/rugged_rover_bringup/CMakeLists.txt
+++ b/rugged_rover_bringup/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 3.8)
+project(rugged_rover_bringup)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(controller_manager REQUIRED)
+find_package(ros2_control REQUIRED)
+find_package(robot_state_publisher REQUIRED)
+find_package(rugged_rover_description REQUIRED)
+find_package(rugged_rover_control REQUIRED)
+find_package(rugged_rover_hardware_interfaces REQUIRED)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # comment the line when a copyright and license is added to all source files
+  set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # comment the line when this package is in a git repo and when
+  # a copyright and license is added to all source files
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/rugged_rover_bringup/config/controllers.yaml
+++ b/rugged_rover_bringup/config/controllers.yaml
@@ -1,28 +1,32 @@
 controller_manager:
   ros__parameters:
-    update_rate: 50
-
+    update_rate: 100
     hardware_platform:
       type: "rugged_rover_hardware_interfaces/sabertooth/SabertoothSystemInterface"
       joints:
-        - front_left_joint
-        - front_right_joint
+        - left_front_wheel_joint
+        - right_front_wheel_joint
+        - left_rear_wheel_joint
+        - right_rear_wheel_joint
       state_interfaces:
         - velocity
       command_interfaces:
         - velocity
+    controller_names:
+      - joint_state_broadcaster
+      - diff_drive_controller
 
-    joint_state_broadcaster:
-      type: "joint_state_broadcaster/JointStateBroadcaster"
+    joint_state_broadcaster.type: joint_state_broadcaster/JointStateBroadcaster
+    diff_drive_controller.type: diff_drive_controller/DiffDriveController
 
-
-    diff_drive_controller:
-      type: diff_drive_controller/DiffDriveController
-      left_wheel_names: ["left_front_wheel_joint", "left_rear_wheel_joint"]
-      right_wheel_names: ["right_front_wheel_joint", "right_rear_wheel_joint"]
-      wheel_separation: 0.4  # Match your URDF value (meters between left and right wheels)
-      wheel_radius: 0.065     # Match your URDF wheel radius (in meters)
-      base_frame_id: base_link
-      cmd_vel_timeout: 0.5
-      use_stamped_vel: false
-      publish_rate: 50.0
+diff_drive_controller:
+  ros__parameters:
+    left_wheel_names: ["left_front_wheel_joint", "left_rear_wheel_joint"]
+    right_wheel_names: ["right_front_wheel_joint", "right_rear_wheel_joint"]
+    wheel_separation: 0.27
+    wheel_radius: 0.065
+    use_stamped_vel: false
+    base_frame_id: base_link
+    cmd_vel_timeout: 0.25
+    publish_rate: 50.0
+    enable_odom_tf: true

--- a/rugged_rover_bringup/config/controllers.yaml
+++ b/rugged_rover_bringup/config/controllers.yaml
@@ -1,0 +1,28 @@
+controller_manager:
+  ros__parameters:
+    update_rate: 50
+
+    hardware_platform:
+      type: "rugged_rover_hardware_interfaces/sabertooth/SabertoothSystemInterface"
+      joints:
+        - front_left_joint
+        - front_right_joint
+      state_interfaces:
+        - velocity
+      command_interfaces:
+        - velocity
+
+    joint_state_broadcaster:
+      type: "joint_state_broadcaster/JointStateBroadcaster"
+
+
+    diff_drive_controller:
+      type: diff_drive_controller/DiffDriveController
+      left_wheel_names: ["left_front_wheel_joint", "left_rear_wheel_joint"]
+      right_wheel_names: ["right_front_wheel_joint", "right_rear_wheel_joint"]
+      wheel_separation: 0.4  # Match your URDF value (meters between left and right wheels)
+      wheel_radius: 0.065     # Match your URDF wheel radius (in meters)
+      base_frame_id: base_link
+      cmd_vel_timeout: 0.5
+      use_stamped_vel: false
+      publish_rate: 50.0

--- a/rugged_rover_bringup/launch/bringup.launch.py
+++ b/rugged_rover_bringup/launch/bringup.launch.py
@@ -1,0 +1,74 @@
+from launch import LaunchDescription
+from launch.substitutions import Command, PathJoinSubstitution
+from launch_ros.substitutions import FindPackageShare
+from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
+
+def generate_launch_description():
+    # Paths to packages and files
+    description_pkg = FindPackageShare("rugged_rover_robot_description")
+    control_pkg = FindPackageShare("rugged_rover_control")
+
+    # Xacro to URDF
+    xacro_path = PathJoinSubstitution([
+        FindPackageShare('rugged_rover_robot_description'),
+        'urdf',
+        'rugged_rover.urdf.xacro'
+    ])
+
+
+    # Convert xacro output into a raw string using Command + ParameterValue
+    # robot_description = {
+    #     "robot_description": ParameterValue(
+    #         Command(["xacro", xacro_file]),
+    #         value_type=str
+    #     )
+    # }
+
+    controllers_yaml = PathJoinSubstitution([
+        control_pkg,
+        "config",
+        "controllers.yaml"
+    ])
+
+    return LaunchDescription([
+        Node(
+            package="micro_ros_agent",
+            executable="micro_ros_agent",
+            name="micro_ros_agent",
+            arguments=["serial", "--dev", "/dev/ttyACM0"],
+            output="screen"
+        ),
+        Node(
+            package="robot_state_publisher",
+            executable="robot_state_publisher",
+            name="robot_state_publisher",
+            parameters=[{'robot_description': ParameterValue(
+                    Command(['xacro ', xacro_path]),
+                    value_type=str
+                )}],
+            output="screen"
+        ),
+        Node(
+            package="controller_manager",
+            executable="ros2_control_node",
+            name="controller_manager",
+            parameters=[{'robot_description': ParameterValue(
+                    Command(['xacro ', xacro_path]),
+                    value_type=str
+                )}, controllers_yaml],
+            output="screen"
+        ),
+        Node(
+            package="controller_manager",
+            executable="spawner",
+            arguments=["joint_state_broadcaster", "--controller-manager", "/controller_manager"],
+            output="screen"
+        ),
+        Node(
+            package="controller_manager",
+            executable="spawner",
+            arguments=["diff_drive_controller", "--controller-manager", "/controller_manager"],
+            output="screen"
+        )
+    ])

--- a/rugged_rover_bringup/package.xml
+++ b/rugged_rover_bringup/package.xml
@@ -13,7 +13,7 @@
   <depend>controller_manager</depend>
   <depend>ros2_control</depend>
   <depend>robot_state_publisher</depend>
-  <depend>rugged_rover_description</depend>
+  <depend>rugged_rover_robot_description</depend>
   <depend>rugged_rover_control</depend>
   <depend>rugged_rover_hardware_interfaces</depend>
 

--- a/rugged_rover_bringup/package.xml
+++ b/rugged_rover_bringup/package.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>rugged_rover_bringup</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="reece.j.holland@gmail.com">reece</maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>controller_manager</depend>
+  <depend>ros2_control</depend>
+  <depend>robot_state_publisher</depend>
+  <depend>rugged_rover_description</depend>
+  <depend>rugged_rover_control</depend>
+  <depend>rugged_rover_hardware_interfaces</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/rugged_rover_control/config/controllers.yaml
+++ b/rugged_rover_control/config/controllers.yaml
@@ -1,28 +1,32 @@
 controller_manager:
   ros__parameters:
-    update_rate: 50
-
+    update_rate: 100
     hardware_platform:
       type: "rugged_rover_hardware_interfaces/sabertooth/SabertoothSystemInterface"
       joints:
-        - front_left_joint
-        - front_right_joint
+        - left_front_wheel_joint
+        - right_front_wheel_joint
+        - left_rear_wheel_joint
+        - right_rear_wheel_joint
       state_interfaces:
         - velocity
       command_interfaces:
         - velocity
+    controller_names:
+      - joint_state_broadcaster
+      - diff_drive_controller
 
-    joint_state_broadcaster:
-      type: "joint_state_broadcaster/JointStateBroadcaster"
+    joint_state_broadcaster.type: joint_state_broadcaster/JointStateBroadcaster
+    diff_drive_controller.type: diff_drive_controller/DiffDriveController
 
-
-    diff_drive_controller:
-      type: diff_drive_controller/DiffDriveController
-      left_wheel_names: ["left_front_wheel_joint", "left_rear_wheel_joint"]
-      right_wheel_names: ["right_front_wheel_joint", "right_rear_wheel_joint"]
-      wheel_separation: 0.4  # Match your URDF value (meters between left and right wheels)
-      wheel_radius: 0.065     # Match your URDF wheel radius (in meters)
-      base_frame_id: base_link
-      cmd_vel_timeout: 0.5
-      use_stamped_vel: false
-      publish_rate: 50.0
+diff_drive_controller:
+  ros__parameters:
+    left_wheel_names: ["left_front_wheel_joint", "left_rear_wheel_joint"]
+    right_wheel_names: ["right_front_wheel_joint", "right_rear_wheel_joint"]
+    wheel_separation: 0.27
+    wheel_radius: 0.065
+    use_stamped_vel: false
+    base_frame_id: base_link
+    cmd_vel_timeout: 0.25
+    publish_rate: 50.0
+    enable_odom_tf: true

--- a/rugged_rover_control/config/controllers.yaml
+++ b/rugged_rover_control/config/controllers.yaml
@@ -15,10 +15,14 @@ controller_manager:
     joint_state_broadcaster:
       type: "joint_state_broadcaster/JointStateBroadcaster"
 
+
     diff_drive_controller:
-      type: "diff_drive_controller/DiffDriveController"
-      left_wheel_names: ["front_left_joint"]
-      right_wheel_names: ["front_right_joint"]
-      wheel_separation: 0.3
-      wheel_radius: 0.1
+      type: diff_drive_controller/DiffDriveController
+      left_wheel_names: ["left_front_wheel_joint", "left_rear_wheel_joint"]
+      right_wheel_names: ["right_front_wheel_joint", "right_rear_wheel_joint"]
+      wheel_separation: 0.4  # Match your URDF value (meters between left and right wheels)
+      wheel_radius: 0.065     # Match your URDF wheel radius (in meters)
       base_frame_id: base_link
+      cmd_vel_timeout: 0.5
+      use_stamped_vel: false
+      publish_rate: 50.0

--- a/rugged_rover_control/launch/control.launch.py
+++ b/rugged_rover_control/launch/control.launch.py
@@ -1,32 +1,67 @@
 from launch import LaunchDescription
+from launch.substitutions import Command, PathJoinSubstitution
+from launch_ros.substitutions import FindPackageShare
 from launch_ros.actions import Node
-from ament_index_python.packages import get_package_share_directory
-import os
+from launch_ros.parameter_descriptions import ParameterValue
 
 def generate_launch_description():
-    config_path = os.path.join(
-        get_package_share_directory('rugged_rover_control'),  # <-- Change this to your actual package
-        'config',
-        'controllers.yaml'
-    )
+    # Paths to packages and files
+    description_pkg = FindPackageShare("rugged_rover_robot_description")
+    control_pkg = FindPackageShare("rugged_rover_control")
+
+    # Xacro to URDF
+    xacro_file = PathJoinSubstitution([
+        description_pkg,
+        "urdf",
+        "rugged_rover.urdf.xacro"
+    ])
+
+    # Convert xacro output into a raw string using Command + ParameterValue
+    robot_description = {
+        "robot_description": ParameterValue(
+            Command(["xacro", xacro_file]),
+            value_type=str
+        )
+    }
+
+    controllers_yaml = PathJoinSubstitution([
+        control_pkg,
+        "config",
+        "controllers.yaml"
+    ])
 
     return LaunchDescription([
         Node(
+            package="micro_ros_agent",
+            executable="micro_ros_agent",
+            name="micro_ros_agent",
+            arguments=["serial", "--dev", "/dev/ttyACM0"],
+            output="screen"
+        ),
+        Node(
+            package="robot_state_publisher",
+            executable="robot_state_publisher",
+            name="robot_state_publisher",
+            parameters=[robot_description],
+            output="screen"
+        ),
+        Node(
             package="controller_manager",
             executable="ros2_control_node",
-            parameters=[config_path],
+            name="controller_manager",
+            parameters=[robot_description, controllers_yaml],
             output="screen"
         ),
         Node(
             package="controller_manager",
             executable="spawner",
-            arguments=["joint_state_broadcaster"],
+            arguments=["joint_state_broadcaster", "--controller-manager", "/controller_manager"],
             output="screen"
         ),
         Node(
             package="controller_manager",
             executable="spawner",
-            arguments=["diff_drive_controller"],
+            arguments=["diff_drive_controller", "--controller-manager", "/controller_manager"],
             output="screen"
         )
     ])

--- a/rugged_rover_robot_description/CMakeLists.txt
+++ b/rugged_rover_robot_description/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(ament_cmake REQUIRED)
 
 # Optional: install xacro files and meshes
 install(
-  DIRECTORY urdf meshes launch rviz config
+  DIRECTORY urdf launch rviz config
   DESTINATION share/${PROJECT_NAME}
 )
 

--- a/rugged_rover_robot_description/urdf/rugged_rover.urdf.xacro
+++ b/rugged_rover_robot_description/urdf/rugged_rover.urdf.xacro
@@ -83,22 +83,22 @@
     <hardware>
       <plugin>rugged_rover_hardware_interfaces/sabertooth/SabertoothSystemInterface</plugin>
     </hardware>
-    <joint name="front_left_joint">
+    <joint name="left_front_wheel_joint">
       <command_interface name="velocity"/>
       <state_interface name="position"/>
       <state_interface name="velocity"/>
     </joint>
-    <joint name="front_right_joint">
+    <joint name="right_front_wheel_joint">
       <command_interface name="velocity"/>
       <state_interface name="position"/>
       <state_interface name="velocity"/>
     </joint>
-    <joint name="rear_left_joint">
+    <joint name="left_rear_wheel_joint">
       <command_interface name="velocity"/>
       <state_interface name="position"/>
       <state_interface name="velocity"/>
     </joint>
-    <joint name="rear_right_joint">
+    <joint name="right_rear_wheel_joint">
       <command_interface name="velocity"/>
       <state_interface name="position"/>
       <state_interface name="velocity"/>


### PR DESCRIPTION
# Pull Request: Add bringup launch system for rugged_rover

## Summary

This pull request introduces the following changes:
- [x] Created new package `rugged_rover_bringup`
- [x] Added `bringup.launch.py` to launch:
  - Robot state publisher with xacro-generated `robot_description`
  - Micro-ROS agent
  - Controller manager and controllers (joint_state_broadcaster, diff_drive_controller)
- [x] Integrated configuration via `controllers.yaml`

---

## Motivation

This PR introduces the primary launch interface for the rugged rover platform. It simplifies deployment by bundling essential nodes (hardware interface, agent, controllers, teleop) into a single entry point.

Resolves: #XX

---

## Testing Strategy

- [x] Verified full launch of `bringup.launch.py` from workspace root
- [x] Confirmed micro-ROS agent starts and responds to Teensy node
- [x] Ensured controllers are successfully loaded and started
- [x] Checked `robot_description` loads without YAML parse errors

**Tested platforms:**
- [x] Ubuntu 22.04 + ROS 2 Humble

---

## Implementation Notes

- Agent is pulled as a git submodule and built with main workspace
- `robot_description` parameter is passed via `ParameterValue(..., str)`
- All node groups are declared in `bringup.launch.py` with correct dependencies

---

## Affected Packages

- `rugged_rover_bringup`

---

## How to Test

```bash
# Clone & init submodules
git clone <repo> && cd <repo>
git submodule update --init --recursive

# Build
colcon build

# Source
. install/setup.bash

# Run bringup
ros2 launch rugged_rover_bringup bringup.launch.py
