### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,114 @@
-# rugged_rover
+# Rugged Rover - A Work in Progress
+
+**Rugged Rover** is a ROS 2-based autonomous mobile robot platform designed to run on the Lynxmotion A4WD3 Rugged Wheeled Rover.
+
+---
+
+## Features
+
+- ROS 2 `ros2_control` integration with custom hardware interface for Sabertooth motor drivers
+- Differential drive controller with 4-wheel support
+- Encoder feedback and velocity control via Teensy 4.1 + micro-ROS
+- Teleoperation via Logitech joystick or keyboard (TODO)
+- Realistic URDF + RViz visualization (Currently Basic)
+- Launch system for hardware and simulation
+- Modular packages for control, description, and hardware
+
+---
+
+## Packages
+
+| Package Name | Description |
+|--------------|-------------|
+| `rugged_rover_hardware_interfaces` | Custom hardware interface for the Sabertooth motor driver |
+| `rugged_rover_robot_description`   | URDF/Xacro model of the rover |
+| `rugged_rover_control`             | Controller YAML configs and `ros2_control` parameters |
+| `rugged_rover_bringup`             | Launch files for bringup and system orchestration |
+| `rugged_rover_joy`                 | Joystick teleoperation node (TODO) |
+| `rugged_rover_interfaces`         | Custom message definitions (e.g., `RoverFeedback`) |
+
+---
+
+## Getting Started
+
+### Prerequisites
+
+- Ubuntu 22.04
+- ROS 2 Humble
+- Colcon workspace setup
+
+### Clone and Build
+
+```bash
+cd ~/ros2_ws/src
+git clone https://github.com/reeceholland/rugged_rover.git
+cd ..
+rosdep install --from-paths src --ignore-src -r -y
+colcon build
+source install/setup.bash
+```
+
+---
+
+## Bringup
+
+### Hardware Launch
+
+```bash
+ros2 launch rugged_rover_bringup bringup.launch.py
+```
+
+
+
+---
+
+
+## Topics Overview
+
+| Topic | Type | Description |
+|-------|------|-------------|
+| `/cmd_vel` | `geometry_msgs/Twist` | Velocity command input |
+| `/joint_states` | `sensor_msgs/JointState` | Joint feedback |
+| `/platform/motors/cmd` | `JointState` or custom | Motor velocity command |
+| `/platform/motors/feedback` | `sensor_msgs/JointState` | Velocity feedback |
+| `/odom` | `nav_msgs/Odometry` | Odometry published by diff drive controller |
+| `/tf` | `tf2_msgs/TFMessage` | Transform tree |
+
+
+---
+
+## Contributing
+
+Pull requests are welcome! Please format code with:
+
+```bash
+find . \( -name "*.cpp" -o -name "*.hpp" \) -exec clang-format -i {} +
+```
+
+Run linters and tests before submitting.
+
+---
+
+## License
+
+This project is licensed under the MIT License. See `LICENSE` file for details.
+
+---
+
+## Roadmap
+
+- [x] Hardware interface integration
+- [x] URDF and visualization
+- [x] Differential drive controller
+- [ ] Teleoperation
+- [ ] EKF-based localization
+- [ ] SLAM and navigation stack
+- [ ] Autonomous waypoint following
+
+---
+
+## 👤 Maintainer
+
+**Reece Holland**  
+https://github.com/reeceholland  
+[reeceholland.github.io](http://reeceholland.github.io/)

--- a/micro_ros_platform_firmware/platform/msg_utils.cpp
+++ b/micro_ros_platform_firmware/platform/msg_utils.cpp
@@ -37,11 +37,11 @@ void initialise_joint_state_message(sensor_msgs__msg__JointState& msg)
   name_data[1].size = strlen(name_data[1].data);
   name_data[1].capacity = MAX_NAME_LEN;
 
-  name_data[2].data = (char *)"rear_left_joint";
+  name_data[2].data = (char*) "rear_left_joint";
   name_data[2].size = strlen(name_data[2].data);
   name_data[2].capacity = MAX_NAME_LEN;
 
-  name_data[3].data = (char *)"rear_right_joint";
+  name_data[3].data = (char*) "rear_right_joint";
   name_data[3].size = strlen(name_data[3].data);
   name_data[3].capacity = MAX_NAME_LEN;
 }

--- a/micro_ros_platform_firmware/platform/msg_utils.cpp
+++ b/micro_ros_platform_firmware/platform/msg_utils.cpp
@@ -14,11 +14,11 @@ double velocity_data[MAX_JOINTS];
 void initialise_joint_state_message(sensor_msgs__msg__JointState& msg)
 {
   msg.name.data = name_data;
-  msg.name.size = 2;
+  msg.name.size = 4;
   msg.name.capacity = MAX_JOINTS;
 
   msg.velocity.data = velocity_data;
-  msg.velocity.size = 2;
+  msg.velocity.size = 4;
   msg.velocity.capacity = MAX_JOINTS;
 
   msg.position.data = NULL;
@@ -29,21 +29,21 @@ void initialise_joint_state_message(sensor_msgs__msg__JointState& msg)
   msg.effort.size = 0;
   msg.effort.capacity = 0;
 
-  name_data[0].data = (char*) "left_front_wheel_joint";
+  name_data[0].data = (char*) "front_left_joint";
   name_data[0].size = strlen(name_data[0].data);
   name_data[0].capacity = MAX_NAME_LEN;
 
-  name_data[1].data = (char*) "right_front_wheel_joint";
+  name_data[1].data = (char*) "front_right_joint";
   name_data[1].size = strlen(name_data[1].data);
   name_data[1].capacity = MAX_NAME_LEN;
 
-  // name_data[2].data = (char *)"left_rear_wheel_joint";
-  // name_data[2].size = strlen(name_data[2].data);
-  // name_data[2].capacity = MAX_NAME_LEN;
+  name_data[2].data = (char *)"rear_left_joint";
+  name_data[2].size = strlen(name_data[2].data);
+  name_data[2].capacity = MAX_NAME_LEN;
 
-  // name_data[3].data = (char *)"right_rear_wheel_joint";
-  // name_data[3].size = strlen(name_data[3].data);
-  // name_data[3].capacity = MAX_NAME_LEN;
+  name_data[3].data = (char *)"rear_right_joint";
+  name_data[3].size = strlen(name_data[3].data);
+  name_data[3].capacity = MAX_NAME_LEN;
 }
 
 void publish_joint_state_message()
@@ -60,14 +60,14 @@ void subscription_callback(const void* msgin)
   {
     const char* name = joint_msg->name.data[i].data;
     float velocity = joint_msg->velocity.data[i];
-    if (strcmp(name, "left_front_wheel_joint") == 0)
+    if (strcmp(name, "front_left_joint") == 0)
       front_left_velocity_setpoint = velocity;
-    else if (strcmp(name, "right_front_wheel_joint") == 0)
+    else if (strcmp(name, "front_right_joint") == 0)
       front_right_velocity_setpoint = velocity;
-    // else if (strcmp(name, "left_rear_wheel_joint") == 0)
+    // else if (strcmp(name, "rear_left_joint") == 0)
     //   front_left_velocity_setpoint = velocity; // Adjust as needed for rear
     //   wheels
-    // else if (strcmp(name, "right_rear_wheel_joint") == 0)
+    // else if (strcmp(name, "rear_right_joint") == 0)
     //   front_right_velocity_setpoint = velocity; // Adjust as needed for rear
     //   wheels
   }

--- a/micro_ros_platform_firmware/platform/msg_utils.hpp
+++ b/micro_ros_platform_firmware/platform/msg_utils.hpp
@@ -2,7 +2,7 @@
 
 #include <sensor_msgs/msg/joint_state.h>
 
-#define MAX_JOINTS 2
+#define MAX_JOINTS 4
 #define MAX_NAME_LEN 25
 
 void initialise_joint_state_message(sensor_msgs__msg__JointState& msg);

--- a/micro_ros_platform_firmware/platform/platform.ino
+++ b/micro_ros_platform_firmware/platform/platform.ino
@@ -18,7 +18,6 @@ void loop() {
     
     sample_encoders();
     publish_joint_state_message();
-    Serial1.print(now - lastEncoderSampleTime);
     update_motors();
   }
   spin_ros_executor();

--- a/rugged_rover_bringup/launch/bringup.launch.py
+++ b/rugged_rover_bringup/launch/bringup.launch.py
@@ -27,7 +27,7 @@ def generate_launch_description():
             package="micro_ros_agent",
             executable="micro_ros_agent",
             name="micro_ros_agent",
-            arguments=["serial", "--dev", "/dev/ttyACM1"],
+            arguments=["serial", "--dev", "/dev/ttyACM0"],
             output="screen"
         ),
         Node(
@@ -71,9 +71,9 @@ def generate_launch_description():
         ),
 
         # Timer action to spawn controllers after a delay
-        # This action waits for 3 seconds before spawning the joint state broadcaster and diff drive controller
+        # This action waits for 4 seconds before spawning the joint state broadcaster and diff drive controller
         TimerAction(
-            period=3.0,
+            period=1.0,
             actions=[
                 Node(
                     package='controller_manager',

--- a/rugged_rover_control/config/controllers.yaml
+++ b/rugged_rover_control/config/controllers.yaml
@@ -4,10 +4,10 @@ controller_manager:
     hardware_platform:
       type: "rugged_rover_hardware_interfaces/sabertooth/SabertoothSystemInterface"
       joints:
-        - left_front_wheel_joint
-        - right_front_wheel_joint
-        - left_rear_wheel_joint
-        - right_rear_wheel_joint
+        - front_left_joint
+        - rear_left_joint
+        - front_right_joint
+        - rear_right_joint
       state_interfaces:
         - velocity
       command_interfaces:
@@ -21,8 +21,8 @@ controller_manager:
 
 diff_drive_controller:
   ros__parameters:
-    left_wheel_names: ["left_front_wheel_joint", "left_rear_wheel_joint"]
-    right_wheel_names: ["right_front_wheel_joint", "right_rear_wheel_joint"]
+    left_wheel_names: ["front_left_joint", "rear_left_joint"]
+    right_wheel_names: ["front_right_joint", "rear_right_joint"]
     wheel_separation: 0.27
     wheel_radius: 0.065
     use_stamped_vel: false

--- a/rugged_rover_hardware_interfaces/include/rugged_rover_hardware_interfaces/sabertooth/sabertooth_system_interface.hpp
+++ b/rugged_rover_hardware_interfaces/include/rugged_rover_hardware_interfaces/sabertooth/sabertooth_system_interface.hpp
@@ -10,8 +10,7 @@
 #include "hardware_interface/system_interface.hpp"
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 #include "rclcpp/rclcpp.hpp"
-
-#include "rugged_rover_interfaces/msg/rover_feedback.hpp"
+#include "sensor_msgs/msg/joint_state.hpp"
 
 namespace rugged_rover_hardware_interfaces::sabertooth
 {
@@ -49,11 +48,11 @@ namespace rugged_rover_hardware_interfaces::sabertooth
   private:
     rclcpp::Node::SharedPtr node_;
 
-    rclcpp::Subscription<rugged_rover_interfaces::msg::RoverFeedback>::SharedPtr feedback_sub_;
+    rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr feedback_sub_;
 
     rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr cmd_pub_;
 
-    void feedbackCallback(const rugged_rover_interfaces::msg::RoverFeedback::SharedPtr msg);
+    void feedbackCallback(const sensor_msgs::msg::JointState::SharedPtr msg);
 
     std::vector<double> hw_positions_;
     std::vector<double> hw_velocities_;
@@ -62,9 +61,7 @@ namespace rugged_rover_hardware_interfaces::sabertooth
 
     rclcpp::Logger logger_ = rclcpp::get_logger("SabertoothSystemInterface");
 
-    double battery_voltage_mv_ = 0.0;
-
-    rugged_rover_interfaces::msg::RoverFeedback last_feedback_;
+    sensor_msgs::msg::JointState last_feedback_;
     std::mutex feedback_mutex_;
 
     friend class SabertoothInterfaceTest;

--- a/rugged_rover_hardware_interfaces/src/sabertooth/sabertooth_system_interface.cpp
+++ b/rugged_rover_hardware_interfaces/src/sabertooth/sabertooth_system_interface.cpp
@@ -167,8 +167,7 @@ namespace rugged_rover_hardware_interfaces::sabertooth
     for (size_t i = 0; i < joint_names_.size(); ++i)
     {
       // Find the index of the joint in the last feedback message
-      auto it = std::find(last_feedback_.name.begin(),
-                          last_feedback_.name.end(), joint_names_[i]);
+      auto it = std::find(last_feedback_.name.begin(), last_feedback_.name.end(), joint_names_[i]);
 
       // If the joint is found.
       if (it != last_feedback_.name.end())
@@ -233,8 +232,8 @@ namespace rugged_rover_hardware_interfaces::sabertooth
    *
    * @param msg The received feedback message.
    */
-  void SabertoothSystemInterface::feedbackCallback(
-      const sensor_msgs::msg::JointState::SharedPtr msg)
+  void
+  SabertoothSystemInterface::feedbackCallback(const sensor_msgs::msg::JointState::SharedPtr msg)
   {
     // Lock the feedback mutex to ensure thread safety
     std::lock_guard<std::mutex> lock(feedback_mutex_);

--- a/rugged_rover_hardware_interfaces/src/sabertooth/sabertooth_system_interface.cpp
+++ b/rugged_rover_hardware_interfaces/src/sabertooth/sabertooth_system_interface.cpp
@@ -65,7 +65,7 @@ namespace rugged_rover_hardware_interfaces::sabertooth
     node_ = rclcpp::Node::make_shared("sabertooth_hw_interface_node");
 
     // Create a subscription to the feedback topic
-    feedback_sub_ = node_->create_subscription<rugged_rover_interfaces::msg::RoverFeedback>(
+    feedback_sub_ = node_->create_subscription<sensor_msgs::msg::JointState>(
         "platform/motors/feedback", rclcpp::SensorDataQoS(),
         std::bind(&SabertoothSystemInterface::feedbackCallback, this, std::placeholders::_1));
 
@@ -127,10 +127,6 @@ namespace rugged_rover_hardware_interfaces::sabertooth
           joint_names_[i], hardware_interface::HW_IF_VELOCITY, &hw_velocities_[i]));
     }
 
-    // Optional battery state
-    state_interfaces.emplace_back(
-        hardware_interface::StateInterface("battery", "voltage_mv", &battery_voltage_mv_));
-
     // Return the vector of state interfaces
     return state_interfaces;
   }
@@ -171,35 +167,22 @@ namespace rugged_rover_hardware_interfaces::sabertooth
     for (size_t i = 0; i < joint_names_.size(); ++i)
     {
       // Find the index of the joint in the last feedback message
-      auto it = std::find(last_feedback_.joint_state.name.begin(),
-                          last_feedback_.joint_state.name.end(), joint_names_[i]);
+      auto it = std::find(last_feedback_.name.begin(),
+                          last_feedback_.name.end(), joint_names_[i]);
 
       // If the joint is found.
-      if (it != last_feedback_.joint_state.name.end())
+      if (it != last_feedback_.name.end())
       {
         // Get the index of the joint in the feedback message
-        size_t index = std::distance(last_feedback_.joint_state.name.begin(), it);
+        size_t index = std::distance(last_feedback_.name.begin(), it);
 
         // Update the hardware positions and velocities if the index is valid
-        if (index < last_feedback_.joint_state.position.size())
-          hw_positions_[i] = last_feedback_.joint_state.position[index];
-        if (index < last_feedback_.joint_state.velocity.size())
-          hw_velocities_[i] = last_feedback_.joint_state.velocity[index];
+        if (index < last_feedback_.position.size())
+          hw_positions_[i] = last_feedback_.position[index];
+        if (index < last_feedback_.velocity.size())
+          hw_velocities_[i] = last_feedback_.velocity[index];
       }
     }
-
-    // Look for battery voltage in the "battery" joint, if published
-    auto bat_it = std::find(last_feedback_.joint_state.name.begin(),
-                            last_feedback_.joint_state.name.end(), "battery");
-
-    // If the battery joint is found, update the battery voltage
-    if (bat_it != last_feedback_.joint_state.name.end())
-    {
-      size_t bat_index = std::distance(last_feedback_.joint_state.name.begin(), bat_it);
-      if (bat_index < last_feedback_.joint_state.effort.size())
-        battery_voltage_mv_ = last_feedback_.joint_state.effort[bat_index];
-    }
-
     // Return OK to indicate successful read operation
     return hardware_interface::return_type::OK;
   }
@@ -251,7 +234,7 @@ namespace rugged_rover_hardware_interfaces::sabertooth
    * @param msg The received feedback message.
    */
   void SabertoothSystemInterface::feedbackCallback(
-      const rugged_rover_interfaces::msg::RoverFeedback::SharedPtr msg)
+      const sensor_msgs::msg::JointState::SharedPtr msg)
   {
     // Lock the feedback mutex to ensure thread safety
     std::lock_guard<std::mutex> lock(feedback_mutex_);

--- a/rugged_rover_robot_description/urdf/rugged_rover.urdf.xacro
+++ b/rugged_rover_robot_description/urdf/rugged_rover.urdf.xacro
@@ -73,32 +73,32 @@
   </xacro:macro>
 
   <!-- Four Wheels -->
-  <xacro:wheel name="left_front_wheel"  x="${ wheel_x_offset}" y="${ wheel_y_offset}"/>
-  <xacro:wheel name="right_front_wheel" x="${ wheel_x_offset}" y="${-wheel_y_offset}"/>
-  <xacro:wheel name="left_rear_wheel"   x="${-wheel_x_offset}" y="${ wheel_y_offset}"/>
-  <xacro:wheel name="right_rear_wheel"  x="${-wheel_x_offset}" y="${-wheel_y_offset}"/>
+  <xacro:wheel name="front_left"  x="${ wheel_x_offset}" y="${ wheel_y_offset}"/>
+  <xacro:wheel name="front_right" x="${ wheel_x_offset}" y="${-wheel_y_offset}"/>
+  <xacro:wheel name="rear_left"   x="${-wheel_x_offset}" y="${ wheel_y_offset}"/>
+  <xacro:wheel name="rear_right"  x="${-wheel_x_offset}" y="${-wheel_y_offset}"/>
 
   <!-- ros2_control: mock interface for joint position -->
   <ros2_control name="RuggedRoverControl" type="system">
     <hardware>
       <plugin>rugged_rover_hardware_interfaces/sabertooth/SabertoothSystemInterface</plugin>
     </hardware>
-    <joint name="left_front_wheel_joint">
+    <joint name="front_left_joint">
       <command_interface name="velocity"/>
       <state_interface name="position"/>
       <state_interface name="velocity"/>
     </joint>
-    <joint name="right_front_wheel_joint">
+    <joint name="front_right_joint">
       <command_interface name="velocity"/>
       <state_interface name="position"/>
       <state_interface name="velocity"/>
     </joint>
-    <joint name="left_rear_wheel_joint">
+    <joint name="rear_left_joint">
       <command_interface name="velocity"/>
       <state_interface name="position"/>
       <state_interface name="velocity"/>
     </joint>
-    <joint name="right_rear_wheel_joint">
+    <joint name="rear_right_joint">
       <command_interface name="velocity"/>
       <state_interface name="position"/>
       <state_interface name="velocity"/>


### PR DESCRIPTION
# Pull Request: Update joint names, hardware interface, and README

## Summary

<!-- Provide a concise summary of what this PR does. -->
This pull request introduces the following changes:
- [x] Updated top-level `README.md` with complete project overview, usage instructions, and topic descriptions
- [x] Renamed joint names across URDF, controller config, and hardware interface for consistency
- [x] Updated `SabertoothSystemInterface` to reflect new joint naming and support velocity command export correctly
- [x] Verified `ros2_control` integration with active joint state and command interfaces

---

## Motivation

<!-- Explain why this change is needed. Reference issues or feature requests if applicable. -->
Resolves: #15  
This update improves clarity and maintainability across the system by enforcing consistent joint naming conventions, improving onboarding via documentation, and ensuring `ros2_control` controllers initialize cleanly.

---

## Testing Strategy

- [x] Built and tested with `colcon build` on ROS 2 Humble
- [x] Ran `ros2 launch rugged_rover_bringup bringup.launch.py` to verify controller and interface activation
- [x] Sent velocity commands via `ros2 topic pub` and observed correct motion in RViz
- [x] Linter and format tools passed (`ament_lint`, `clang-format`, etc.)

**Tested platforms:**
- [x] Ubuntu 22.04 + ROS 2 Humble
- [ ] Ubuntu 20.04 + ROS 2 Foxy
- [ ] Other: ____

---

## Implementation Notes

<!-- Detail any design decisions, protocol changes, or assumptions. -->
- Joint names now use the consistent convention: `front_left_joint`, `rear_right_joint`, etc.
- `export_command_interfaces()` and `export_state_interfaces()` updated to use renamed joints
- New `README.md` added at the top level with features, launch instructions, and topic maps
- Verified plugin registration and runtime controller activation via `ros2 control list_controllers`

---

## Affected Packages

- `rugged_rover_robot_description`
- `rugged_rover_control`
- `rugged_rover_hardware_interfaces`
- `rugged_rover_bringup`

---

## How to Test

```bash
# Build
colcon build --packages-select rugged_rover_robot_description rugged_rover_control rugged_rover_hardware_interfaces rugged_rover_bringup

# Source
. install/setup.bash

# Launch full stack
ros2 launch rugged_rover_bringup bringup.launch.py

# Send velocity command
ros2 topic pub /diff_drive_controller/cmd_vel_unstamped geometry_msgs/Twist "linear:
  x: 0.5
  y: 0.0
  z: 0.0
angular:
  x: 0.0
  y: 0.0
  z: 0.0" -r 10

# Visualize in RViz
rviz2
