### PR TITLE
Add joystick teleop support

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,41 @@ ros2 topic echo /platform/motors/cmd --once
 ros2 control list_controllers
 ```
 
+## Joystick Teleop
+
+Start joystick teleop after the main hardware or Unity sim stack is running:
+
+```bash
+ros2 launch rugged_rover_bringup joy.launch.py
+```
+
+By default this launches `joy_node` and `teleop_twist_joy`, then remaps the output directly to:
+
+```text
+/diff_drive_controller/cmd_vel
+```
+
+The default config uses an Xbox-style layout:
+
+- Hold `LB` to enable driving
+- Hold `RB` as well for turbo speed
+- Left stick vertical controls forward and reverse
+- Right stick horizontal controls rotation
+
+Use a different joystick device id if needed:
+
+```bash
+ros2 launch rugged_rover_bringup joy.launch.py joy_dev:=1
+```
+
+Debug the controller and teleop mapping with:
+
+```bash
+ros2 launch rugged_rover_bringup joy_debug.launch.py
+```
+
+That launch prints both raw `/joy` messages and the generated `/diff_drive_controller/cmd_vel` commands.
+
 ## Teensy Firmware Notes
 
 The firmware lives in:

--- a/rugged_rover_bringup/config/joy.yaml
+++ b/rugged_rover_bringup/config/joy.yaml
@@ -1,0 +1,32 @@
+joy_node:
+  ros__parameters:
+    device_id: 0
+    deadzone: 0.15
+    autorepeat_rate: 20.0
+
+teleop_twist_joy_node:
+  ros__parameters:
+    # Hold this button while driving. On many Xbox-style controllers this is LB.
+    enable_button: 4
+
+    # Hold this button as well for the faster scale. On many Xbox-style controllers this is RB.
+    enable_turbo_button: 5
+
+    # Left stick vertical controls forward/back.
+    axis_linear:
+      x: 1
+    scale_linear:
+      x: 0.30
+    scale_linear_turbo:
+      x: 0.60
+
+    # Right stick horizontal controls yaw.
+    axis_angular:
+      yaw: 3
+    scale_angular:
+      yaw: 1.20
+    scale_angular_turbo:
+      yaw: 2.00
+
+    # ROS 2 Jazzy diff_drive_controller subscribes to TwistStamped by default.
+    publish_stamped_twist: true

--- a/rugged_rover_bringup/launch/joy.launch.py
+++ b/rugged_rover_bringup/launch/joy.launch.py
@@ -1,0 +1,54 @@
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+    bringup_pkg = FindPackageShare("rugged_rover_bringup")
+
+    joy_config = PathJoinSubstitution([
+        bringup_pkg,
+        "config",
+        "joy.yaml",
+    ])
+
+    joy_dev = LaunchConfiguration("joy_dev")
+    cmd_vel_topic = LaunchConfiguration("cmd_vel_topic")
+
+    return LaunchDescription([
+        DeclareLaunchArgument(
+            "joy_dev",
+            default_value="0",
+            description="Joystick device id passed to joy_node.",
+        ),
+
+        DeclareLaunchArgument(
+            "cmd_vel_topic",
+            default_value="/diff_drive_controller/cmd_vel",
+            description="Velocity command topic for joystick teleop.",
+        ),
+
+        Node(
+            package="joy",
+            executable="joy_node",
+            name="joy_node",
+            parameters=[
+                joy_config,
+                {"device_id": joy_dev},
+            ],
+            output="screen",
+        ),
+
+        Node(
+            package="teleop_twist_joy",
+            executable="teleop_node",
+            name="teleop_twist_joy_node",
+            parameters=[joy_config],
+            remappings=[
+                ("/cmd_vel", cmd_vel_topic),
+            ],
+            output="screen",
+        ),
+    ])

--- a/rugged_rover_bringup/launch/joy_debug.launch.py
+++ b/rugged_rover_bringup/launch/joy_debug.launch.py
@@ -1,0 +1,74 @@
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, ExecuteProcess
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+    bringup_pkg = FindPackageShare("rugged_rover_bringup")
+
+    joy_config = PathJoinSubstitution([
+        bringup_pkg,
+        "config",
+        "joy.yaml",
+    ])
+
+    joy_dev = LaunchConfiguration("joy_dev")
+    cmd_vel_topic = LaunchConfiguration("cmd_vel_topic")
+
+    return LaunchDescription([
+        DeclareLaunchArgument(
+            "joy_dev",
+            default_value="0",
+            description="Joystick device id passed to joy_node.",
+        ),
+
+        DeclareLaunchArgument(
+            "cmd_vel_topic",
+            default_value="/diff_drive_controller/cmd_vel",
+            description="Velocity command topic produced by teleop_twist_joy.",
+        ),
+
+        Node(
+            package="joy",
+            executable="joy_node",
+            name="joy_node",
+            parameters=[
+                joy_config,
+                {"device_id": joy_dev},
+            ],
+            output="screen",
+        ),
+
+        Node(
+            package="teleop_twist_joy",
+            executable="teleop_node",
+            name="teleop_twist_joy_node",
+            parameters=[joy_config],
+            remappings=[
+                ("/cmd_vel", cmd_vel_topic),
+            ],
+            output="screen",
+        ),
+
+        ExecuteProcess(
+            cmd=[
+                "ros2",
+                "topic",
+                "echo",
+                "/joy",
+            ],
+            output="screen",
+        ),
+
+        ExecuteProcess(
+            cmd=[
+                "ros2",
+                "topic",
+                "echo",
+                cmd_vel_topic,
+            ],
+            output="screen",
+        ),
+    ])

--- a/rugged_rover_bringup/package.xml
+++ b/rugged_rover_bringup/package.xml
@@ -22,6 +22,8 @@
   <exec_depend>nav2_bringup</exec_depend>
   <exec_depend>navigation2</exec_depend>
   <exec_depend>topic_tools</exec_depend>
+  <exec_depend>joy</exec_depend>
+  <exec_depend>teleop_twist_joy</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
# Add joystick teleop support

## Summary

Adds joystick teleoperation support for the rover through `joy_node` and `teleop_twist_joy`.

## Changes

- Added `rugged_rover_bringup/config/joy.yaml` with Xbox-style controller mappings.
- Added `joy.launch.py` to start joystick input and teleop command publishing.
- Added `joy_debug.launch.py` to echo raw `/joy` input and generated velocity commands.
- Added `joy` and `teleop_twist_joy` runtime dependencies to `rugged_rover_bringup/package.xml`.
- Documented joystick usage, controls, device selection, and debug launch commands in the README.

## Usage

Start joystick teleop:

```bash
ros2 launch rugged_rover_bringup joy.launch.py
```

Use a different joystick device:

```bash
ros2 launch rugged_rover_bringup joy.launch.py joy_dev:=1
```

Debug joystick input and generated velocity commands:

```bash
ros2 launch rugged_rover_bringup joy_debug.launch.py
```

## Testing

```bash
colcon build --symlink-install --packages-select rugged_rover_bringup rugged_rover_control rugged_rover_hardware_interfaces rugged_rover_robot_description
```
