### PR TITLE
Support Teensy UART connection to Raspberry Pi

### DIFF
--- a/micro_ros_platform_firmware/platform/error_handling.hpp
+++ b/micro_ros_platform_firmware/platform/error_handling.hpp
@@ -6,13 +6,21 @@
 
 void error_loop();
 
+inline void report_micro_ros_error(const char* message, int rc = 0)
+{
+  // Do not print on Serial1 here: Serial1 is the micro-ROS transport to the Pi.
+  // The LED blink in error_loop() is the hardware-visible failure indicator.
+  (void)message;
+  (void)rc;
+}
+
 // Macro helpers for micro-ROS error handling
 #define RCCHECK(fn)                                                                                \
   {                                                                                                \
     rcl_ret_t temp_rc = fn;                                                                        \
     if ((temp_rc != RCL_RET_OK))                                                                   \
     {                                                                                              \
-      Serial1.println("Hard error!");                                                              \
+      report_micro_ros_error("Hard error", temp_rc);                                               \
       error_loop();                                                                                \
     }                                                                                              \
   }
@@ -21,7 +29,6 @@ void error_loop();
     rcl_ret_t temp_rc = fn;                                                                        \
     if ((temp_rc != RCL_RET_OK))                                                                   \
     {                                                                                              \
-      Serial1.print("Soft error: ");                                                               \
-      Serial1.println(temp_rc);                                                                    \
+      report_micro_ros_error("Soft error", temp_rc);                                               \
     }                                                                                              \
   }

--- a/micro_ros_platform_firmware/platform/error_handling.hpp
+++ b/micro_ros_platform_firmware/platform/error_handling.hpp
@@ -10,8 +10,8 @@ inline void report_micro_ros_error(const char* message, int rc = 0)
 {
   // Do not print on Serial1 here: Serial1 is the micro-ROS transport to the Pi.
   // The LED blink in error_loop() is the hardware-visible failure indicator.
-  (void)message;
-  (void)rc;
+  (void) message;
+  (void) rc;
 }
 
 // Macro helpers for micro-ROS error handling

--- a/micro_ros_platform_firmware/platform/msg_utils.cpp
+++ b/micro_ros_platform_firmware/platform/msg_utils.cpp
@@ -9,10 +9,14 @@
 #include "ros_interface.hpp"
 #include <cstring>
 
-rosidl_runtime_c__String name_data[MAX_JOINTS];
-char name_buffer[MAX_JOINTS][MAX_NAME_LEN];
-double position_data[MAX_JOINTS];
-double velocity_data[MAX_JOINTS];
+rosidl_runtime_c__String cmd_name_data[MAX_JOINTS];
+rosidl_runtime_c__String feedback_name_data[MAX_JOINTS];
+char cmd_name_buffer[MAX_JOINTS][MAX_NAME_LEN];
+char feedback_name_buffer[MAX_JOINTS][MAX_NAME_LEN];
+double cmd_position_data[MAX_JOINTS];
+double cmd_velocity_data[MAX_JOINTS];
+double feedback_position_data[MAX_JOINTS];
+double feedback_velocity_data[MAX_JOINTS];
 
 namespace
 {
@@ -36,15 +40,22 @@ namespace
  */
 void initialise_joint_state_message(sensor_msgs__msg__JointState& msg)
 {
-  msg.name.data = name_data;
+  const bool is_feedback_msg = (&msg == &feedback_msg);
+
+  rosidl_runtime_c__String* names = is_feedback_msg ? feedback_name_data : cmd_name_data;
+  char (*name_storage)[MAX_NAME_LEN] = is_feedback_msg ? feedback_name_buffer : cmd_name_buffer;
+  double* positions = is_feedback_msg ? feedback_position_data : cmd_position_data;
+  double* velocities = is_feedback_msg ? feedback_velocity_data : cmd_velocity_data;
+
+  msg.name.data = names;
   msg.name.size = 4;
   msg.name.capacity = MAX_JOINTS;
 
-  msg.velocity.data = velocity_data;
+  msg.velocity.data = velocities;
   msg.velocity.size = 4;
   msg.velocity.capacity = MAX_JOINTS;
 
-  msg.position.data = position_data;
+  msg.position.data = positions;
   msg.position.size = 4;
   msg.position.capacity = MAX_JOINTS;
 
@@ -54,13 +65,13 @@ void initialise_joint_state_message(sensor_msgs__msg__JointState& msg)
 
   for (size_t i = 0; i < MAX_JOINTS; ++i)
   {
-    strncpy(name_buffer[i], JOINT_NAMES[i], MAX_NAME_LEN - 1);
-    name_buffer[i][MAX_NAME_LEN - 1] = '\0';
-    name_data[i].data = name_buffer[i];
-    name_data[i].size = strlen(name_buffer[i]);
-    name_data[i].capacity = MAX_NAME_LEN;
-    position_data[i] = 0.0;
-    velocity_data[i] = 0.0;
+    strncpy(name_storage[i], JOINT_NAMES[i], MAX_NAME_LEN - 1);
+    name_storage[i][MAX_NAME_LEN - 1] = '\0';
+    names[i].data = name_storage[i];
+    names[i].size = strlen(name_storage[i]);
+    names[i].capacity = MAX_NAME_LEN;
+    positions[i] = 0.0;
+    velocities[i] = 0.0;
   }
 }
 
@@ -104,6 +115,11 @@ void subscription_callback(const void* msgin)
   //  velocity setpoint
   for (size_t i = 0; i < joint_msg->name.size && i < MAX_JOINTS; i++)
   {
+    if (i >= joint_msg->velocity.size)
+    {
+      break;
+    }
+
     const char* name = joint_msg->name.data[i].data;
     float velocity = joint_msg->velocity.data[i];
     if (strcmp(name, "front_left_joint") == 0)

--- a/micro_ros_platform_firmware/platform/msg_utils.cpp
+++ b/micro_ros_platform_firmware/platform/msg_utils.cpp
@@ -43,7 +43,7 @@ void initialise_joint_state_message(sensor_msgs__msg__JointState& msg)
   const bool is_feedback_msg = (&msg == &feedback_msg);
 
   rosidl_runtime_c__String* names = is_feedback_msg ? feedback_name_data : cmd_name_data;
-  char (*name_storage)[MAX_NAME_LEN] = is_feedback_msg ? feedback_name_buffer : cmd_name_buffer;
+  char(*name_storage)[MAX_NAME_LEN] = is_feedback_msg ? feedback_name_buffer : cmd_name_buffer;
   double* positions = is_feedback_msg ? feedback_position_data : cmd_position_data;
   double* velocities = is_feedback_msg ? feedback_velocity_data : cmd_velocity_data;
 

--- a/micro_ros_platform_firmware/platform/ros_interface.cpp
+++ b/micro_ros_platform_firmware/platform/ros_interface.cpp
@@ -20,6 +20,33 @@ rcl_node_t node;
 sensor_msgs__msg__JointState cmd_msg;
 sensor_msgs__msg__JointState feedback_msg;
 
+extern "C" bool arduino_transport_open(struct uxrCustomTransport*)
+{
+  Serial1.begin(115200);
+  return true;
+}
+
+extern "C" bool arduino_transport_close(struct uxrCustomTransport*)
+{
+  Serial1.end();
+  return true;
+}
+
+extern "C" size_t arduino_transport_write(struct uxrCustomTransport*, const uint8_t* buf,
+                                          size_t len, uint8_t* err)
+{
+  (void)err;
+  return Serial1.write(buf, len);
+}
+
+extern "C" size_t arduino_transport_read(struct uxrCustomTransport*, uint8_t* buf, size_t len,
+                                         int timeout, uint8_t* err)
+{
+  (void)err;
+  Serial1.setTimeout(timeout);
+  return Serial1.readBytes(reinterpret_cast<char*>(buf), len);
+}
+
 /**
  * @brief Setup the micro-ROS environment and initialize the node.
  *
@@ -29,10 +56,14 @@ sensor_msgs__msg__JointState feedback_msg;
  */
 void ros_setup()
 {
-  //  Serial setup for the Sabertooth
+  // Serial2 is reserved for Teensy -> Sabertooth motor commands.
   Serial2.begin(9600);
 
-  // micro-ROS transport setup
+  // Serial1 is the Raspberry Pi <-> Teensy micro-ROS transport.
+  // Wire Pi TXD0 GPIO14/pin 8  -> Teensy RX1/pin 0
+  // Wire Pi RXD0 GPIO15/pin 10 -> Teensy TX1/pin 1
+  // Wire Pi GND                -> Teensy GND
+  Serial1.begin(115200);
   set_microros_transports();
 
   pinMode(LED_PIN, OUTPUT);

--- a/micro_ros_platform_firmware/platform/ros_interface.cpp
+++ b/micro_ros_platform_firmware/platform/ros_interface.cpp
@@ -35,14 +35,14 @@ extern "C" bool arduino_transport_close(struct uxrCustomTransport*)
 extern "C" size_t arduino_transport_write(struct uxrCustomTransport*, const uint8_t* buf,
                                           size_t len, uint8_t* err)
 {
-  (void)err;
+  (void) err;
   return Serial1.write(buf, len);
 }
 
 extern "C" size_t arduino_transport_read(struct uxrCustomTransport*, uint8_t* buf, size_t len,
                                          int timeout, uint8_t* err)
 {
-  (void)err;
+  (void) err;
   Serial1.setTimeout(timeout);
   return Serial1.readBytes(reinterpret_cast<char*>(buf), len);
 }

--- a/rugged_rover_bringup/launch/bringup.launch.py
+++ b/rugged_rover_bringup/launch/bringup.launch.py
@@ -1,12 +1,14 @@
 from launch import LaunchDescription
 from launch_ros.actions import Node
-from launch.substitutions import Command, PathJoinSubstitution
+from launch.substitutions import Command, LaunchConfiguration, PathJoinSubstitution
 from launch_ros.substitutions import FindPackageShare
-from launch.actions import TimerAction
+from launch.actions import DeclareLaunchArgument, TimerAction
 from launch_ros.parameter_descriptions import ParameterValue
 
 
 def generate_launch_description():
+    micro_ros_device = LaunchConfiguration('micro_ros_device')
+
     # Construct the path to the URDF file using xacro
     xacro_path = PathJoinSubstitution([
         FindPackageShare('rugged_rover_robot_description'),
@@ -23,11 +25,16 @@ def generate_launch_description():
 
     # Create the launch description
     return LaunchDescription([
+        DeclareLaunchArgument(
+            'micro_ros_device',
+            default_value='/dev/ttyAMA0',
+            description='Serial device used by the micro-ROS Agent.'
+        ),
         Node(
             package="micro_ros_agent",
             executable="micro_ros_agent",
             name="micro_ros_agent",
-            arguments=["serial", "--dev", "/dev/ttyACM0"],
+            arguments=["serial", "--dev", micro_ros_device],
             output="screen"
         ),
         Node(


### PR DESCRIPTION
## Summary

Adds support for connecting the Teensy 4.1 to the Raspberry Pi over GPIO UART instead of USB serial.

## Changes

- Route micro-ROS transport through Teensy `Serial1`
- Keep Sabertooth motor commands on `Serial2`
- Stop error handling from printing on `Serial1`, since it is now the micro-ROS transport
- Separate command and feedback `JointState` buffers in the Teensy firmware
- Guard against reading past the incoming velocity array in the motor command callback
- Make `bringup.launch.py` use `/dev/ttyAMA0` by default for the Pi UART
- Add `micro_ros_device` launch argument for overriding the serial device

## Testing

- Verified Raspberry Pi UART loopback on `/dev/ttyAMA0`
- Verified micro-ROS Agent opens `/dev/ttyAMA0`
- Verified Teensy establishes a micro-ROS session over Pi UART
- Python syntax checked `bringup.launch.py`