### PR TITLE
Add battery voltage telemetry

### DIFF
--- a/micro_ros_platform_firmware/platform/battery_monitor.cpp
+++ b/micro_ros_platform_firmware/platform/battery_monitor.cpp
@@ -1,0 +1,20 @@
+// battery_monitor.cpp
+#include "battery_monitor.hpp"
+#include "config.hpp"
+#include <Arduino.h>
+
+void setup_battery_monitor()
+{
+  analogReadResolution(12);
+}
+
+float read_battery_voltage()
+{
+  constexpr float ADC_MAX = 4095.0f;
+
+  const int raw = analogRead(BATTERY_VOLTAGE_PIN);
+
+  const float pin_voltage = (static_cast<float>(raw) / ADC_MAX) * ADC_REFERENCE_VOLTAGE;
+
+  return pin_voltage * (BATTERY_R_TOP + BATTERY_R_BOTTOM) / BATTERY_R_BOTTOM;
+}

--- a/micro_ros_platform_firmware/platform/battery_monitor.hpp
+++ b/micro_ros_platform_firmware/platform/battery_monitor.hpp
@@ -1,0 +1,5 @@
+// battery_monitor.hpp
+#pragma once
+
+void setup_battery_monitor();
+float read_battery_voltage();

--- a/micro_ros_platform_firmware/platform/config.hpp
+++ b/micro_ros_platform_firmware/platform/config.hpp
@@ -5,3 +5,10 @@
 #define USE_ROS 1
 
 extern bool SERIAL_DEBUG;
+
+#define BATTERY_VOLTAGE_PIN A0
+
+constexpr float BATTERY_R_TOP = 100000.0f;
+constexpr float BATTERY_R_BOTTOM = 33000.0f;
+constexpr float ADC_REFERENCE_VOLTAGE = 3.3f;
+constexpr float BATTERY_PUBLISH_PERIOD_MS = 1000.0f;

--- a/micro_ros_platform_firmware/platform/config.hpp
+++ b/micro_ros_platform_firmware/platform/config.hpp
@@ -6,7 +6,7 @@
 
 extern bool SERIAL_DEBUG;
 
-#define BATTERY_VOLTAGE_PIN A0
+#define BATTERY_VOLTAGE_PIN A9
 
 constexpr float BATTERY_R_TOP = 100000.0f;
 constexpr float BATTERY_R_BOTTOM = 33000.0f;

--- a/micro_ros_platform_firmware/platform/msg_utils.cpp
+++ b/micro_ros_platform_firmware/platform/msg_utils.cpp
@@ -1,4 +1,5 @@
 #include "msg_utils.hpp"
+#include "battery_monitor.hpp"
 #include "config.hpp"
 
 #if USE_ROS
@@ -7,6 +8,7 @@
 #include "motor_control.hpp"
 #include "msg_utils.hpp"
 #include "ros_interface.hpp"
+#include <Arduino.h>
 #include <cstring>
 
 rosidl_runtime_c__String cmd_name_data[MAX_JOINTS];
@@ -75,6 +77,27 @@ void initialise_joint_state_message(sensor_msgs__msg__JointState& msg)
   }
 }
 
+void initialise_battery_voltage_message(std_msgs__msg__Float32& msg)
+{
+  msg.data = 0.0f;
+}
+
+void publish_battery_voltage_message()
+{
+  static unsigned long last_publish_ms = 0;
+  unsigned long now = millis();
+
+  if (now - last_publish_ms < BATTERY_PUBLISH_PERIOD_MS)
+  {
+    return;
+  }
+
+  last_publish_ms = now;
+
+  battery_voltage_msg.data = read_battery_voltage();
+  RCSOFTCHECK(rcl_publish(&battery_voltage_publisher, &battery_voltage_msg, NULL));
+}
+
 /**
  * @brief Publish the JointState message with current velocity data.
  *
@@ -139,4 +162,5 @@ void subscription_callback(const void* msgin)
 }
 #else
 void publish_joint_state_message() {}
+void publish_battery_voltage_message() {}
 #endif

--- a/micro_ros_platform_firmware/platform/msg_utils.hpp
+++ b/micro_ros_platform_firmware/platform/msg_utils.hpp
@@ -3,7 +3,9 @@
 #include "config.hpp"
 
 #if USE_ROS
+#include <micro_ros_arduino.h>
 #include <sensor_msgs/msg/joint_state.h>
+#include <std_msgs/msg/float32.h>
 #endif
 
 #define MAX_JOINTS 4
@@ -11,8 +13,10 @@
 
 #if USE_ROS
 void initialise_joint_state_message(sensor_msgs__msg__JointState& msg);
+void initialise_battery_voltage_message(std_msgs__msg__Float32& msg);
 #endif
 void publish_joint_state_message();
+void publish_battery_voltage_message();
 #if USE_ROS
 void subscription_callback(const void* msgin);
 #endif

--- a/micro_ros_platform_firmware/platform/platform.ino
+++ b/micro_ros_platform_firmware/platform/platform.ino
@@ -1,119 +1,145 @@
-#include <Arduino.h>
-#include "ros_interface.hpp"
+#include "battery_monitor.hpp"
+#include "config.hpp"
 #include "encoder_utils.hpp"
 #include "motor_control.hpp"
 #include "msg_utils.hpp"
-#include "config.hpp"
+#include "ros_interface.hpp"
+#include <Arduino.h>
 
 bool SERIAL_DEBUG = !USE_ROS;
 
-namespace {
+namespace
+{
 
-String serial_line;
+  String serial_line;
 
-void print_serial_help() {
-  Serial.println();
-  Serial.println("Rugged Rover motor bench mode");
-  Serial.println("Send: <left_rad_s> <right_rad_s>");
-  Serial.println("Example: 1.5 1.5");
-  Serial.println("Send: s");
-  Serial.println("Stops both motors.");
-  Serial.println();
-}
-
-void handle_serial_command(const String &line) {
-  String trimmed = line;
-  trimmed.trim();
-
-  if (trimmed.length() == 0) {
-    return;
+  void print_serial_help()
+  {
+    Serial.println();
+    Serial.println("Rugged Rover motor bench mode");
+    Serial.println("Send: <left_rad_s> <right_rad_s>");
+    Serial.println("Example: 1.5 1.5");
+    Serial.println("Send: s");
+    Serial.println("Stops both motors.");
+    Serial.println();
   }
 
-  if (trimmed == "s" || trimmed == "S" || trimmed == "stop") {
-    stop_motors();
-    Serial.println("Setpoints: left=0.000 rad/s, right=0.000 rad/s");
-    return;
+  void handle_serial_command(const String& line)
+  {
+    String trimmed = line;
+    trimmed.trim();
+
+    if (trimmed.length() == 0)
+    {
+      return;
+    }
+
+    if (trimmed == "s" || trimmed == "S" || trimmed == "stop")
+    {
+      stop_motors();
+      Serial.println("Setpoints: left=0.000 rad/s, right=0.000 rad/s");
+      return;
+    }
+
+    char buffer[64];
+    trimmed.toCharArray(buffer, sizeof(buffer));
+
+    char* end = nullptr;
+    const float left = strtof(buffer, &end);
+
+    if (end == buffer)
+    {
+      Serial.println("Could not parse left setpoint.");
+      print_serial_help();
+      return;
+    }
+
+    while (*end == ' ' || *end == ',' || *end == '\t')
+    {
+      ++end;
+    }
+
+    char* right_end = nullptr;
+    const float right = strtof(end, &right_end);
+
+    if (right_end == end)
+    {
+      Serial.println("Could not parse right setpoint.");
+      print_serial_help();
+      return;
+    }
+
+    front_left_velocity_setpoint = left;
+    front_right_velocity_setpoint = right;
+
+    Serial.print("Setpoints: left=");
+    Serial.print(front_left_velocity_setpoint, 3);
+    Serial.print(" rad/s, right=");
+    Serial.print(front_right_velocity_setpoint, 3);
+    Serial.println(" rad/s");
   }
 
-  char buffer[64];
-  trimmed.toCharArray(buffer, sizeof(buffer));
+  void read_serial_commands()
+  {
+    while (Serial.available() > 0)
+    {
+      const char c = static_cast<char>(Serial.read());
 
-  char *end = nullptr;
-  const float left = strtof(buffer, &end);
-
-  if (end == buffer) {
-    Serial.println("Could not parse left setpoint.");
-    print_serial_help();
-    return;
-  }
-
-  while (*end == ' ' || *end == ',' || *end == '\t') {
-    ++end;
-  }
-
-  char *right_end = nullptr;
-  const float right = strtof(end, &right_end);
-
-  if (right_end == end) {
-    Serial.println("Could not parse right setpoint.");
-    print_serial_help();
-    return;
-  }
-
-  front_left_velocity_setpoint = left;
-  front_right_velocity_setpoint = right;
-
-  Serial.print("Setpoints: left=");
-  Serial.print(front_left_velocity_setpoint, 3);
-  Serial.print(" rad/s, right=");
-  Serial.print(front_right_velocity_setpoint, 3);
-  Serial.println(" rad/s");
-}
-
-void read_serial_commands() {
-  while (Serial.available() > 0) {
-    const char c = static_cast<char>(Serial.read());
-
-    if (c == '\n' || c == '\r') {
-      handle_serial_command(serial_line);
-      serial_line = "";
-    } else if (serial_line.length() < 63) {
-      serial_line += c;
+      if (c == '\n' || c == '\r')
+      {
+        handle_serial_command(serial_line);
+        serial_line = "";
+      }
+      else if (serial_line.length() < 63)
+      {
+        serial_line += c;
+      }
     }
   }
-}
 
-}  // namespace
+} // namespace
 
-void setup() {
+void setup()
+{
   Serial2.begin(9600);
 
-  if (USE_ROS) {
+  if (USE_ROS)
+  {
     ros_setup();
-  } else {
+  }
+  else
+  {
     Serial.begin(115200);
     delay(1000);
     print_serial_help();
   }
 
   setup_pid();
+  setup_battery_monitor();
 }
 
-void loop() {
+void loop()
+{
 
   unsigned long now = millis();
-  if (now - lastEncoderSampleTime >= 50) {
-    
+  if (now - lastEncoderSampleTime >= 50)
+  {
+
     sample_encoders();
-    if (USE_ROS) {
+    if (USE_ROS)
+    {
       publish_joint_state_message();
+      publish_battery_voltage_message();
     }
     update_motors();
   }
 
-  if (USE_ROS) {
+  if (USE_ROS)
+  {
     spin_ros_executor();
-  } else {
+  }
+  else
+  {
     read_serial_commands();
   }
 }

--- a/micro_ros_platform_firmware/platform/ros_interface.cpp
+++ b/micro_ros_platform_firmware/platform/ros_interface.cpp
@@ -9,6 +9,7 @@
 #include <rmw/qos_profiles.h>
 #include <rmw_microros/ping.h>
 #include <sensor_msgs/msg/joint_state.h>
+#include <std_msgs/msg/float32.h>
 
 rcl_subscription_t joint_state_subscriber;
 rcl_publisher_t feedback_publisher;
@@ -16,9 +17,11 @@ rclc_executor_t executor;
 rcl_allocator_t allocator;
 rclc_support_t support;
 rcl_node_t node;
+rcl_publisher_t battery_voltage_publisher;
 
 sensor_msgs__msg__JointState cmd_msg;
 sensor_msgs__msg__JointState feedback_msg;
+std_msgs__msg__Float32 battery_voltage_msg;
 
 extern "C" bool arduino_transport_open(struct uxrCustomTransport*)
 {
@@ -90,6 +93,7 @@ void ros_setup()
   sensor_msgs__msg__JointState__init(&feedback_msg);
   initialise_joint_state_message(cmd_msg);
   initialise_joint_state_message(feedback_msg);
+  initialise_battery_voltage_message(battery_voltage_msg);
 
   const rosidl_message_type_support_t* type_support =
       ROSIDL_GET_MSG_TYPE_SUPPORT(sensor_msgs, msg, JointState);
@@ -97,11 +101,17 @@ void ros_setup()
   rcl_subscription_options_t sub_ops = rcl_subscription_get_default_options();
   sub_ops.qos = rmw_qos_profile_sensor_data;
 
-  RCCHECK(rcl_subscription_init(&joint_state_subscriber, &node, type_support, "platform/motors/cmd",
-                                &sub_ops));
-
   rcl_publisher_options_t pub_ops = rcl_publisher_get_default_options();
   pub_ops.qos = rmw_qos_profile_sensor_data;
+
+  const rosidl_message_type_support_t* battery_type_support =
+      ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Float32);
+
+  RCCHECK(rcl_publisher_init(&battery_voltage_publisher, &node, battery_type_support,
+                             "battery/voltage", &pub_ops));
+
+  RCCHECK(rcl_subscription_init(&joint_state_subscriber, &node, type_support, "platform/motors/cmd",
+                                &sub_ops));
 
   RCCHECK(rcl_publisher_init(&feedback_publisher, &node, type_support, "platform/motors/feedback",
                              &pub_ops));

--- a/micro_ros_platform_firmware/platform/ros_interface.hpp
+++ b/micro_ros_platform_firmware/platform/ros_interface.hpp
@@ -8,6 +8,7 @@
 #include <rclc/executor.h>
 #include <rclc/rclc.h>
 #include <sensor_msgs/msg/joint_state.h>
+#include <std_msgs/msg/float32.h>
 #endif
 
 void ros_setup();
@@ -19,6 +20,8 @@ extern rcl_node_t node;
 extern rclc_executor_t executor;
 extern rcl_subscription_t joint_state_subscriber;
 extern rcl_publisher_t feedback_publisher;
+extern rcl_publisher_t battery_voltage_publisher;
 extern sensor_msgs__msg__JointState cmd_msg;
 extern sensor_msgs__msg__JointState feedback_msg;
+extern std_msgs__msg__Float32 battery_voltage_msg;
 #endif


### PR DESCRIPTION
# Add battery voltage telemetry

## Summary

Adds Teensy-side battery voltage monitoring and publishes the measured pack voltage over ROS.

## Changes

- Added `battery_monitor.cpp/.hpp` for ADC setup and voltage divider conversion
- Added battery voltage divider constants in `config.hpp`
- Published `/battery/voltage` as `std_msgs/msg/Float32`
- Integrated battery voltage publishing into the existing firmware loop
- Added ROS publisher state for battery telemetry
- Kept the ADC measurement logic separate from ROS message publishing

## Testing

- Verified the voltage divider hardware reports battery voltage correctly
- Confirmed `/battery/voltage` publishes from the Teensy through micro-ROS
- Ran `clang-format` on the updated firmware files