### PR TITLE
Add rplidar s2 bringup

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 [submodule "rugged_rover_imu"]
 	path = rugged_rover_imu
 	url = https://github.com/reeceholland/razor_imu.git
+[submodule "sllidar_ros2"]
+	path = sllidar_ros2
+	url = https://github.com/Slamtec/sllidar_ros2.git

--- a/micro_ros_platform_firmware/platform/battery_safety.cpp
+++ b/micro_ros_platform_firmware/platform/battery_safety.cpp
@@ -1,0 +1,32 @@
+#include "battery_safety.hpp"
+
+namespace
+{
+  constexpr float kCriticalVoltage = 10.5f;
+  constexpr float kRecoverVoltage = 11.1f;
+
+  bool critical_latched = false;
+} // namespace
+
+void battery_safety_setup()
+{
+  critical_latched = false;
+}
+
+void battery_safety_update(float battery_voltage)
+{
+  if (battery_voltage <= kCriticalVoltage)
+  {
+    critical_latched = true;
+  }
+}
+
+bool battery_is_critical()
+{
+  return critical_latched;
+}
+
+void battery_clear_latch_for_debug()
+{
+  critical_latched = false;
+}

--- a/micro_ros_platform_firmware/platform/battery_safety.cpp
+++ b/micro_ros_platform_firmware/platform/battery_safety.cpp
@@ -19,6 +19,10 @@ void battery_safety_update(float battery_voltage)
   {
     critical_latched = true;
   }
+  else if (battery_voltage >= kRecoverVoltage)
+  {
+    critical_latched = false;
+  }
 }
 
 bool battery_is_critical()

--- a/micro_ros_platform_firmware/platform/battery_safety.hpp
+++ b/micro_ros_platform_firmware/platform/battery_safety.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+void battery_safety_setup();
+void battery_safety_update(float battery_voltage);
+
+bool battery_is_critical();
+void battery_clear_latch_for_debug();

--- a/micro_ros_platform_firmware/platform/config.hpp
+++ b/micro_ros_platform_firmware/platform/config.hpp
@@ -12,3 +12,4 @@ constexpr float BATTERY_R_TOP = 100000.0f;
 constexpr float BATTERY_R_BOTTOM = 33000.0f;
 constexpr float ADC_REFERENCE_VOLTAGE = 3.3f;
 constexpr float BATTERY_PUBLISH_PERIOD_MS = 1000.0f;
+constexpr unsigned long MOTOR_COMMAND_TIMEOUT_MS = 500;

--- a/micro_ros_platform_firmware/platform/motor_control.cpp
+++ b/micro_ros_platform_firmware/platform/motor_control.cpp
@@ -30,6 +30,7 @@ float front_right_velocity_setpoint = 0;
 //  PID outputs
 float front_left_output = 0;
 float front_right_output = 0;
+unsigned long last_motor_command_ms = 0;
 
 //  The PID controller for the front left motor
 QuickPID front_left_pid(&current_front_left_rads_sec, &front_left_output,
@@ -53,6 +54,11 @@ void setup_pid()
 
   front_left_pid.SetMode(QuickPID::Control::automatic);
   front_right_pid.SetMode(QuickPID::Control::automatic);
+}
+
+void mark_motor_command_received()
+{
+  last_motor_command_ms = millis();
 }
 
 void stop_motors()
@@ -106,6 +112,12 @@ void send_sabertooth_command(HardwareSerial& port, byte address, byte motor, int
 void update_motors()
 {
   if (battery_is_critical())
+  {
+    stop_motors();
+    return;
+  }
+  if (USE_ROS &&
+      (last_motor_command_ms == 0 || millis() - last_motor_command_ms > MOTOR_COMMAND_TIMEOUT_MS))
   {
     stop_motors();
     return;

--- a/micro_ros_platform_firmware/platform/motor_control.cpp
+++ b/micro_ros_platform_firmware/platform/motor_control.cpp
@@ -1,4 +1,5 @@
 #include "motor_control.hpp"
+#include "battery_safety.hpp"
 #include "config.hpp"
 
 namespace
@@ -104,6 +105,11 @@ void send_sabertooth_command(HardwareSerial& port, byte address, byte motor, int
  */
 void update_motors()
 {
+  if (battery_is_critical())
+  {
+    stop_motors();
+    return;
+  }
   if (abs(front_left_velocity_setpoint) <= SETPOINT_DEADBAND_RAD_S &&
       abs(front_right_velocity_setpoint) <= SETPOINT_DEADBAND_RAD_S)
   {

--- a/micro_ros_platform_firmware/platform/motor_control.hpp
+++ b/micro_ros_platform_firmware/platform/motor_control.hpp
@@ -17,6 +17,7 @@ extern float front_left_velocity_setpoint;
 extern float front_right_velocity_setpoint;
 extern float front_left_output;
 extern float front_right_output;
+extern unsigned long last_motor_command_ms;
 extern QuickPID front_left_pid;
 extern QuickPID front_right_pid;
 
@@ -25,6 +26,7 @@ extern float current_front_left_rads_sec;
 extern float current_front_right_rads_sec;
 
 void setup_pid();
+void mark_motor_command_received();
 void stop_motors();
 void send_sabertooth_command(HardwareSerial& port, byte address, byte motor, int speed);
 void update_motors();

--- a/micro_ros_platform_firmware/platform/msg_utils.cpp
+++ b/micro_ros_platform_firmware/platform/msg_utils.cpp
@@ -1,5 +1,6 @@
 #include "msg_utils.hpp"
 #include "battery_monitor.hpp"
+#include "battery_safety.hpp"
 #include "config.hpp"
 
 #if USE_ROS
@@ -45,7 +46,7 @@ void initialise_joint_state_message(sensor_msgs__msg__JointState& msg)
   const bool is_feedback_msg = (&msg == &feedback_msg);
 
   rosidl_runtime_c__String* names = is_feedback_msg ? feedback_name_data : cmd_name_data;
-  char(*name_storage)[MAX_NAME_LEN] = is_feedback_msg ? feedback_name_buffer : cmd_name_buffer;
+  char (*name_storage)[MAX_NAME_LEN] = is_feedback_msg ? feedback_name_buffer : cmd_name_buffer;
   double* positions = is_feedback_msg ? feedback_position_data : cmd_position_data;
   double* velocities = is_feedback_msg ? feedback_velocity_data : cmd_velocity_data;
 
@@ -131,6 +132,11 @@ void publish_joint_state_message()
  */
 void subscription_callback(const void* msgin)
 {
+  if (battery_is_critical())
+  {
+    stop_motors();
+    return;
+  }
   //  Cast the incoming message to the expected type
   const sensor_msgs__msg__JointState* joint_msg = (const sensor_msgs__msg__JointState*) msgin;
 

--- a/micro_ros_platform_firmware/platform/msg_utils.cpp
+++ b/micro_ros_platform_firmware/platform/msg_utils.cpp
@@ -139,6 +139,7 @@ void subscription_callback(const void* msgin)
   }
   //  Cast the incoming message to the expected type
   const sensor_msgs__msg__JointState* joint_msg = (const sensor_msgs__msg__JointState*) msgin;
+  bool received_motor_command = false;
 
   //  For each joint in the message, check the name and update the corresponding
   //  velocity setpoint
@@ -152,13 +153,30 @@ void subscription_callback(const void* msgin)
     const char* name = joint_msg->name.data[i].data;
     float velocity = joint_msg->velocity.data[i];
     if (strcmp(name, "front_left_joint") == 0)
+    {
       front_left_velocity_setpoint = velocity;
+      received_motor_command = true;
+    }
     else if (strcmp(name, "front_right_joint") == 0)
+    {
       front_right_velocity_setpoint = velocity;
+      received_motor_command = true;
+    }
     else if (strcmp(name, "rear_left_joint") == 0)
+    {
       front_left_velocity_setpoint = velocity;
+      received_motor_command = true;
+    }
     else if (strcmp(name, "rear_right_joint") == 0)
+    {
       front_right_velocity_setpoint = velocity;
+      received_motor_command = true;
+    }
+  }
+
+  if (received_motor_command)
+  {
+    mark_motor_command_received();
   }
 
   if (abs(front_left_velocity_setpoint) <= 0.05 && abs(front_right_velocity_setpoint) <= 0.05)

--- a/micro_ros_platform_firmware/platform/platform.ino
+++ b/micro_ros_platform_firmware/platform/platform.ino
@@ -1,9 +1,11 @@
 #include "battery_monitor.hpp"
+#include "battery_safety.hpp"
 #include "config.hpp"
 #include "encoder_utils.hpp"
 #include "motor_control.hpp"
 #include "msg_utils.hpp"
 #include "ros_interface.hpp"
+#include "status_led.hpp"
 #include <Arduino.h>
 
 bool SERIAL_DEBUG = !USE_ROS;
@@ -116,6 +118,8 @@ void setup()
 
   setup_pid();
   setup_battery_monitor();
+  battery_safety_setup();
+  status_led_setup();
 }
 
 void loop()
@@ -126,7 +130,7 @@ void loop()
   {
 
     sample_encoders();
-    if (USE_ROS)
+    if (USE_ROS && ros_is_connected())
     {
       publish_joint_state_message();
       publish_battery_voltage_message();
@@ -136,10 +140,25 @@ void loop()
 
   if (USE_ROS)
   {
-    spin_ros_executor();
+    ros_update();
   }
   else
   {
     read_serial_commands();
+  }
+
+  battery_safety_update(read_battery_voltage());
+
+  if (battery_is_critical())
+  {
+    status_led_update(LedStatus::BatteryCritical);
+  }
+  else if (ros_is_connected())
+  {
+    status_led_update(LedStatus::RosConnected);
+  }
+  else
+  {
+    status_led_update(LedStatus::Normal);
   }
 }

--- a/micro_ros_platform_firmware/platform/platform.ino
+++ b/micro_ros_platform_firmware/platform/platform.ino
@@ -73,6 +73,7 @@ namespace
 
     front_left_velocity_setpoint = left;
     front_right_velocity_setpoint = right;
+    mark_motor_command_received();
 
     Serial.print("Setpoints: left=");
     Serial.print(front_left_velocity_setpoint, 3);
@@ -103,6 +104,7 @@ namespace
 
 void setup()
 {
+  Serial.begin(115200);
   Serial2.begin(9600);
 
   if (USE_ROS)
@@ -111,7 +113,6 @@ void setup()
   }
   else
   {
-    Serial.begin(115200);
     delay(1000);
     print_serial_help();
   }
@@ -136,6 +137,25 @@ void loop()
       publish_battery_voltage_message();
     }
     update_motors();
+  }
+
+  if (USE_ROS)
+  {
+    static unsigned long last_debug_ms = 0;
+    if (now - last_debug_ms >= 1000)
+    {
+      last_debug_ms = now;
+      Serial.print("ros=");
+      Serial.print(ros_is_connected() ? "connected" : "waiting");
+      Serial.print(" battery_critical=");
+      Serial.print(battery_is_critical() ? "true" : "false");
+      Serial.print(" last_cmd_age_ms=");
+      Serial.print(last_motor_command_ms == 0 ? -1 : static_cast<long>(now - last_motor_command_ms));
+      Serial.print(" setpoints FL=");
+      Serial.print(front_left_velocity_setpoint, 3);
+      Serial.print(" FR=");
+      Serial.println(front_right_velocity_setpoint, 3);
+    }
   }
 
   if (USE_ROS)

--- a/micro_ros_platform_firmware/platform/ros_interface.cpp
+++ b/micro_ros_platform_firmware/platform/ros_interface.cpp
@@ -50,12 +50,159 @@ extern "C" size_t arduino_transport_read(struct uxrCustomTransport*, uint8_t* bu
   return Serial1.readBytes(reinterpret_cast<char*>(buf), len);
 }
 
+namespace
+{
+  enum class RosConnectionState
+  {
+    WaitingForAgent,
+    Connected,
+  };
+
+  RosConnectionState ros_state = RosConnectionState::WaitingForAgent;
+  unsigned long last_agent_ping_ms = 0;
+  bool support_created = false;
+  bool node_created = false;
+  bool battery_publisher_created = false;
+  bool motor_subscription_created = false;
+  bool feedback_publisher_created = false;
+  bool executor_created = false;
+  bool ros_entities_created = false;
+
+  constexpr unsigned long AGENT_PING_PERIOD_MS = 1000;
+  constexpr int AGENT_PING_TIMEOUT_MS = 100;
+  constexpr int AGENT_PING_ATTEMPTS = 1;
+
+  void destroy_ros_entities();
+
+  bool create_ros_entities()
+  {
+    destroy_ros_entities();
+
+    allocator = rcl_get_default_allocator();
+
+    if (rclc_support_init(&support, 0, NULL, &allocator) != RCL_RET_OK)
+    {
+      return false;
+    }
+    support_created = true;
+
+    if (rclc_node_init_default(&node, "micro_ros_platform_node", "", &support) != RCL_RET_OK)
+    {
+      destroy_ros_entities();
+      return false;
+    }
+    node_created = true;
+
+    rcutils_logging_set_default_logger_level(RCUTILS_LOG_SEVERITY_DEBUG);
+
+    sensor_msgs__msg__JointState__init(&cmd_msg);
+    sensor_msgs__msg__JointState__init(&feedback_msg);
+    initialise_joint_state_message(cmd_msg);
+    initialise_joint_state_message(feedback_msg);
+    initialise_battery_voltage_message(battery_voltage_msg);
+
+    const rosidl_message_type_support_t* type_support =
+        ROSIDL_GET_MSG_TYPE_SUPPORT(sensor_msgs, msg, JointState);
+    const rosidl_message_type_support_t* battery_type_support =
+        ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Float32);
+
+    rcl_subscription_options_t sub_ops = rcl_subscription_get_default_options();
+    sub_ops.qos = rmw_qos_profile_sensor_data;
+
+    rcl_publisher_options_t pub_ops = rcl_publisher_get_default_options();
+    pub_ops.qos = rmw_qos_profile_sensor_data;
+
+    if (rcl_publisher_init(&battery_voltage_publisher, &node, battery_type_support,
+                           "battery/voltage", &pub_ops) != RCL_RET_OK)
+    {
+      destroy_ros_entities();
+      return false;
+    }
+    battery_publisher_created = true;
+
+    if (rcl_subscription_init(&joint_state_subscriber, &node, type_support,
+                              "platform/motors/cmd", &sub_ops) != RCL_RET_OK)
+    {
+      destroy_ros_entities();
+      return false;
+    }
+    motor_subscription_created = true;
+
+    if (rcl_publisher_init(&feedback_publisher, &node, type_support,
+                           "platform/motors/feedback", &pub_ops) != RCL_RET_OK)
+    {
+      destroy_ros_entities();
+      return false;
+    }
+    feedback_publisher_created = true;
+
+    if (rclc_executor_init(&executor, &support.context, 1, &allocator) != RCL_RET_OK)
+    {
+      destroy_ros_entities();
+      return false;
+    }
+    executor_created = true;
+
+    if (rclc_executor_add_subscription(&executor, &joint_state_subscriber, &cmd_msg,
+                                       &subscription_callback, ON_NEW_DATA) != RCL_RET_OK)
+    {
+      destroy_ros_entities();
+      return false;
+    }
+
+    ros_entities_created = true;
+    return true;
+  }
+
+  void destroy_ros_entities()
+  {
+    if (executor_created)
+    {
+      rclc_executor_fini(&executor);
+      executor_created = false;
+    }
+
+    if (feedback_publisher_created)
+    {
+      rcl_publisher_fini(&feedback_publisher, &node);
+      feedback_publisher_created = false;
+    }
+
+    if (battery_publisher_created)
+    {
+      rcl_publisher_fini(&battery_voltage_publisher, &node);
+      battery_publisher_created = false;
+    }
+
+    if (motor_subscription_created)
+    {
+      rcl_subscription_fini(&joint_state_subscriber, &node);
+      motor_subscription_created = false;
+    }
+
+    if (node_created)
+    {
+      rcl_node_fini(&node);
+      node_created = false;
+    }
+
+    if (support_created)
+    {
+      rclc_support_fini(&support);
+      support_created = false;
+    }
+
+    ros_entities_created = false;
+  }
+
+  bool agent_is_available()
+  {
+    return rmw_uros_ping_agent(AGENT_PING_TIMEOUT_MS, AGENT_PING_ATTEMPTS) == RMW_RET_OK;
+  }
+} // namespace
+
 /**
- * @brief Setup the micro-ROS environment and initialize the node.
- *
- * This function initializes the micro-ROS node, sets up the serial
- * communication, and prepares the JointState message for publishing and
- * subscribing.
+ * @brief Prepare serial transports. ROS entities are created by ros_update().
  */
 void ros_setup()
 {
@@ -69,71 +216,70 @@ void ros_setup()
   Serial1.begin(115200);
   set_microros_transports();
 
-  pinMode(LED_PIN, OUTPUT);
-  digitalWrite(LED_PIN, HIGH);
+  ros_state = RosConnectionState::WaitingForAgent;
+  last_agent_ping_ms = 0;
+}
 
-  // Give the agent a moment to appear before creating ROS entities. This is
-  // especially helpful after USB reconnects and Teensy uploads.
-  while (rmw_uros_ping_agent(100, 5) != RMW_RET_OK)
+bool ros_is_connected()
+{
+  return ros_state == RosConnectionState::Connected;
+}
+
+void ros_update()
+{
+  const unsigned long now = millis();
+
+  if (ros_state == RosConnectionState::WaitingForAgent)
   {
-    digitalWrite(LED_PIN, !digitalRead(LED_PIN));
-    delay(100);
+    if (now - last_agent_ping_ms < AGENT_PING_PERIOD_MS)
+      return;
+
+    last_agent_ping_ms = now;
+
+    if (agent_is_available())
+    {
+      destroy_ros_entities();
+      if (create_ros_entities())
+      {
+        ros_state = RosConnectionState::Connected;
+      }
+      else
+      {
+        stop_motors();
+        destroy_ros_entities();
+      }
+    }
+    return;
   }
 
-  digitalWrite(LED_PIN, HIGH);
+  spin_ros_executor();
 
-  // ROS node and entities
-  allocator = rcl_get_default_allocator();
-  RCCHECK(rclc_support_init(&support, 0, NULL, &allocator));
-  RCCHECK(rclc_node_init_default(&node, "micro_ros_platform_node", "", &support));
+  if (now - last_agent_ping_ms >= AGENT_PING_PERIOD_MS)
+  {
+    last_agent_ping_ms = now;
 
-  rcutils_logging_set_default_logger_level(RCUTILS_LOG_SEVERITY_DEBUG);
-
-  sensor_msgs__msg__JointState__init(&cmd_msg);
-  sensor_msgs__msg__JointState__init(&feedback_msg);
-  initialise_joint_state_message(cmd_msg);
-  initialise_joint_state_message(feedback_msg);
-  initialise_battery_voltage_message(battery_voltage_msg);
-
-  const rosidl_message_type_support_t* type_support =
-      ROSIDL_GET_MSG_TYPE_SUPPORT(sensor_msgs, msg, JointState);
-
-  rcl_subscription_options_t sub_ops = rcl_subscription_get_default_options();
-  sub_ops.qos = rmw_qos_profile_sensor_data;
-
-  rcl_publisher_options_t pub_ops = rcl_publisher_get_default_options();
-  pub_ops.qos = rmw_qos_profile_sensor_data;
-
-  const rosidl_message_type_support_t* battery_type_support =
-      ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Float32);
-
-  RCCHECK(rcl_publisher_init(&battery_voltage_publisher, &node, battery_type_support,
-                             "battery/voltage", &pub_ops));
-
-  RCCHECK(rcl_subscription_init(&joint_state_subscriber, &node, type_support, "platform/motors/cmd",
-                                &sub_ops));
-
-  RCCHECK(rcl_publisher_init(&feedback_publisher, &node, type_support, "platform/motors/feedback",
-                             &pub_ops));
-
-  RCCHECK(rclc_executor_init(&executor, &support.context, 1, &allocator));
-  RCCHECK(rclc_executor_add_subscription(&executor, &joint_state_subscriber, &cmd_msg,
-                                         &subscription_callback, ON_NEW_DATA));
+    if (!agent_is_available())
+    {
+      stop_motors();
+      destroy_ros_entities();
+      ros_state = RosConnectionState::WaitingForAgent;
+    }
+  }
 }
 
 /**
  * @brief Spin the ROS executor to process incoming messages.
- *
- * This function processes incoming messages and executes the associated
- * callbacks.
- *
  */
 void spin_ros_executor()
 {
-  //  Spin the executor to process incoming messages
+  if (!ros_entities_created)
+    return;
+
   RCSOFTCHECK(rclc_executor_spin_some(&executor, RCL_MS_TO_NS(5)));
 }
 #else
 void ros_setup() {}
+void ros_update() {}
 void spin_ros_executor() {}
+bool ros_is_connected() { return false; }
 #endif

--- a/micro_ros_platform_firmware/platform/ros_interface.cpp
+++ b/micro_ros_platform_firmware/platform/ros_interface.cpp
@@ -241,6 +241,8 @@ void ros_update()
       destroy_ros_entities();
       if (create_ros_entities())
       {
+        stop_motors();
+        last_motor_command_ms = 0;
         ros_state = RosConnectionState::Connected;
       }
       else
@@ -261,6 +263,7 @@ void ros_update()
     if (!agent_is_available())
     {
       stop_motors();
+      last_motor_command_ms = 0;
       destroy_ros_entities();
       ros_state = RosConnectionState::WaitingForAgent;
     }

--- a/micro_ros_platform_firmware/platform/ros_interface.hpp
+++ b/micro_ros_platform_firmware/platform/ros_interface.hpp
@@ -12,7 +12,9 @@
 #endif
 
 void ros_setup();
+void ros_update();
 void spin_ros_executor();
+bool ros_is_connected();
 
 #if USE_ROS
 // External ROS-related objects used across modules

--- a/micro_ros_platform_firmware/platform/status_led.cpp
+++ b/micro_ros_platform_firmware/platform/status_led.cpp
@@ -1,0 +1,63 @@
+// status_led.cpp
+#include "status_led.hpp"
+#include <Arduino.h>
+
+namespace
+{
+  constexpr int kLedPin = LED_BUILTIN;
+
+  unsigned long last_change_ms = 0;
+  int step = 0;
+
+  void set_led(bool on)
+  {
+    digitalWrite(kLedPin, on ? HIGH : LOW);
+  }
+} // namespace
+
+void status_led_setup()
+{
+  pinMode(kLedPin, OUTPUT);
+  set_led(false);
+}
+
+void status_led_update(LedStatus status)
+{
+  const unsigned long now = millis();
+
+  if (status == LedStatus::BatteryCritical)
+  {
+    // 3 quick blinks, pause, repeat.
+    constexpr unsigned long pattern[] = {120, 120, 120, 120, 120, 700};
+
+    if (now - last_change_ms >= pattern[step])
+    {
+      last_change_ms = now;
+      step = (step + 1) % 6;
+      set_led(step % 2 == 1);
+    }
+    return;
+  }
+
+  if (status == LedStatus::RosConnected)
+  {
+    // Double blink, pause.
+    constexpr unsigned long pattern[] = {100, 100, 100, 900};
+
+    if (now - last_change_ms >= pattern[step])
+    {
+      last_change_ms = now;
+      step = (step + 1) % 4;
+      set_led(step % 2 == 1);
+    }
+    return;
+  }
+
+  // Normal heartbeat.
+  if (now - last_change_ms >= 1000)
+  {
+    last_change_ms = now;
+    step = !step;
+    set_led(step);
+  }
+}

--- a/micro_ros_platform_firmware/platform/status_led.hpp
+++ b/micro_ros_platform_firmware/platform/status_led.hpp
@@ -1,0 +1,12 @@
+// status_led.hpp
+#pragma once
+
+enum class LedStatus
+{
+  Normal,
+  RosConnected,
+  BatteryCritical,
+};
+
+void status_led_setup();
+void status_led_update(LedStatus status);

--- a/rugged_rover_battery/CMakeLists.txt
+++ b/rugged_rover_battery/CMakeLists.txt
@@ -1,0 +1,50 @@
+cmake_minimum_required(VERSION 3.8)
+project(rugged_rover_battery)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(diagnostic_msgs REQUIRED)
+
+add_executable(battery_voltage_monitor
+  src/main.cpp
+  src/battery_voltage_monitor.cpp
+)
+
+target_include_directories(battery_voltage_monitor PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+
+ament_target_dependencies(battery_voltage_monitor
+  rclcpp
+  std_msgs
+  diagnostic_msgs
+)
+
+install(TARGETS battery_voltage_monitor
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+install(DIRECTORY include/
+  DESTINATION include
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # comment the line when a copyright and license is added to all source files
+  set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # comment the line when this package is in a git repo and when
+  # a copyright and license is added to all source files
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/rugged_rover_battery/include/rugged_rover_battery/battery_voltage_monitor.hpp
+++ b/rugged_rover_battery/include/rugged_rover_battery/battery_voltage_monitor.hpp
@@ -1,0 +1,37 @@
+#ifndef RUGGED_ROVER_BATTERY__BATTERY_VOLTAGE_MONITOR_HPP
+#define RUGGED_ROVER_BATTERY__BATTERY_VOLTAGE_MONITOR_HPP
+
+#include <diagnostic_msgs/msg/diagnostic_array.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/bool.hpp>
+#include <std_msgs/msg/float32.hpp>
+
+namespace rugged_rover_battery
+{
+
+  class BatteryVoltageMonitor : public rclcpp::Node
+  {
+  public:
+    BatteryVoltageMonitor();
+
+  private:
+    void batteryVoltageCallback(const std_msgs::msg::Float32::SharedPtr msg);
+    void publishState(float voltage);
+    void publishDiagnostics(float voltage, bool is_low, bool is_critical);
+    void timerCallback();
+
+    rclcpp::Subscription<std_msgs::msg::Float32>::SharedPtr battery_voltage_sub_;
+
+    rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr battery_low_pub_;
+    rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr battery_critical_pub_;
+    rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr diagnostics_pub_;
+
+    double low_voltage_;
+    double critical_voltage_;
+    double stale_timout_;
+
+    rclcpp::Time last_voltage_time_;
+    bool has_voltage_;
+  };
+} // namespace rugged_rover_battery
+#endif // RUGGED_ROVER_BATTERY__BATTERY_VOLTAGE_MONITOR_HPP

--- a/rugged_rover_battery/include/rugged_rover_battery/battery_voltage_monitor.hpp
+++ b/rugged_rover_battery/include/rugged_rover_battery/battery_voltage_monitor.hpp
@@ -21,6 +21,7 @@ namespace rugged_rover_battery
     void timerCallback();
 
     rclcpp::Subscription<std_msgs::msg::Float32>::SharedPtr battery_voltage_sub_;
+    rclcpp::TimerBase::SharedPtr stale_timer_;
 
     rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr battery_low_pub_;
     rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr battery_critical_pub_;
@@ -28,7 +29,7 @@ namespace rugged_rover_battery
 
     double low_voltage_;
     double critical_voltage_;
-    double stale_timout_;
+    double stale_timeout_;
 
     rclcpp::Time last_voltage_time_;
     bool has_voltage_;

--- a/rugged_rover_battery/package.xml
+++ b/rugged_rover_battery/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>rugged_rover_battery</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="reece.j.holland@gmail.com">reece</maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>std_msgs</depend>
+  <depend>diagnostic_msgs</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/rugged_rover_battery/src/battery_voltage_monitor.cpp
+++ b/rugged_rover_battery/src/battery_voltage_monitor.cpp
@@ -12,22 +12,23 @@ namespace rugged_rover_battery
     // Get parameter values
     this->get_parameter("low_voltage_threshold", low_voltage_);
     this->get_parameter("critical_voltage_threshold", critical_voltage_);
-    this->get_parameter("stale_timeout", stale_timout_);
+    this->get_parameter("stale_timeout", stale_timeout_);
 
     // Initialize publishers
     battery_low_pub_ = this->create_publisher<std_msgs::msg::Bool>("battery_low", 10);
-    battery_critical_pub_ = this->create_publisher<std_msgs::msg::Bool>("battery_critical", 10);
+    battery_critical_pub_ =
+        this->create_publisher<std_msgs::msg::Bool>("platform/battery/is_critical", 10);
     diagnostics_pub_ =
         this->create_publisher<diagnostic_msgs::msg::DiagnosticArray>("diagnostics", 10);
 
     auto timer_period = std::chrono::milliseconds(500);
 
-    auto timer = this->create_wall_timer(timer_period,
-                                         std::bind(&BatteryVoltageMonitor::timerCallback, this));
+    stale_timer_ = this->create_wall_timer(
+        timer_period, std::bind(&BatteryVoltageMonitor::timerCallback, this));
 
-    // Initialize subscriber
+    // Initialize subscriber. Teensy firmware and Unity publish the raw voltage here.
     battery_voltage_sub_ = this->create_subscription<std_msgs::msg::Float32>(
-        "battery_voltage", 10,
+        "battery/voltage", 10,
         std::bind(&BatteryVoltageMonitor::batteryVoltageCallback, this, std::placeholders::_1));
 
     has_voltage_ = false;
@@ -97,7 +98,7 @@ namespace rugged_rover_battery
     }
 
     auto now = this->now();
-    if ((now - last_voltage_time_).seconds() > stale_timout_)
+    if ((now - last_voltage_time_).seconds() > stale_timeout_)
     {
       RCLCPP_WARN(this->get_logger(), "Battery voltage data is stale!");
       publishDiagnostics(0.0, true, true); // Publish critical status for stale data

--- a/rugged_rover_battery/src/battery_voltage_monitor.cpp
+++ b/rugged_rover_battery/src/battery_voltage_monitor.cpp
@@ -1,0 +1,106 @@
+#include "rugged_rover_battery/battery_voltage_monitor.hpp"
+
+namespace rugged_rover_battery
+{
+  BatteryVoltageMonitor::BatteryVoltageMonitor() : Node("battery_voltage_monitor")
+  {
+    // Declare parameters with default values
+    this->declare_parameter<double>("low_voltage_threshold", 11.0);
+    this->declare_parameter<double>("critical_voltage_threshold", 10.5);
+    this->declare_parameter<double>("stale_timeout", 5.0);
+
+    // Get parameter values
+    this->get_parameter("low_voltage_threshold", low_voltage_);
+    this->get_parameter("critical_voltage_threshold", critical_voltage_);
+    this->get_parameter("stale_timeout", stale_timout_);
+
+    // Initialize publishers
+    battery_low_pub_ = this->create_publisher<std_msgs::msg::Bool>("battery_low", 10);
+    battery_critical_pub_ = this->create_publisher<std_msgs::msg::Bool>("battery_critical", 10);
+    diagnostics_pub_ =
+        this->create_publisher<diagnostic_msgs::msg::DiagnosticArray>("diagnostics", 10);
+
+    auto timer_period = std::chrono::milliseconds(500);
+
+    auto timer = this->create_wall_timer(timer_period,
+                                         std::bind(&BatteryVoltageMonitor::timerCallback, this));
+
+    // Initialize subscriber
+    battery_voltage_sub_ = this->create_subscription<std_msgs::msg::Float32>(
+        "battery_voltage", 10,
+        std::bind(&BatteryVoltageMonitor::batteryVoltageCallback, this, std::placeholders::_1));
+
+    has_voltage_ = false;
+  }
+
+  void BatteryVoltageMonitor::batteryVoltageCallback(const std_msgs::msg::Float32::SharedPtr msg)
+  {
+    float voltage = msg->data;
+    last_voltage_time_ = this->now();
+    has_voltage_ = true;
+
+    publishState(voltage);
+    publishDiagnostics(voltage, voltage < low_voltage_, voltage < critical_voltage_);
+  }
+
+  void BatteryVoltageMonitor::publishState(float voltage)
+  {
+    std_msgs::msg::Bool low_msg;
+    low_msg.data = voltage < low_voltage_;
+    battery_low_pub_->publish(low_msg);
+
+    std_msgs::msg::Bool critical_msg;
+    critical_msg.data = voltage < critical_voltage_;
+    battery_critical_pub_->publish(critical_msg);
+  }
+
+  void BatteryVoltageMonitor::publishDiagnostics(float voltage, bool is_low, bool is_critical)
+  {
+    diagnostic_msgs::msg::DiagnosticArray diag_array;
+    diagnostic_msgs::msg::DiagnosticStatus status;
+
+    diag_array.header.stamp = now();
+
+    status.name = "rugged_rover_battery: Battery Voltage";
+    status.hardware_id = "battery_monitor";
+
+    diagnostic_msgs::msg::KeyValue voltage_value;
+    voltage_value.key = "voltage_v";
+    voltage_value.value = std::to_string(voltage);
+    status.values.push_back(voltage_value);
+
+    if (is_critical)
+    {
+      status.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+      status.message = "Battery voltage is critical";
+    }
+    else if (is_low)
+    {
+      status.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+      status.message = "Battery voltage is low";
+    }
+    else
+    {
+      status.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+      status.message = "Battery voltage is normal";
+    }
+
+    diag_array.status.push_back(status);
+    diagnostics_pub_->publish(diag_array);
+  }
+
+  void BatteryVoltageMonitor::timerCallback()
+  {
+    if (!has_voltage_)
+    {
+      return; // No voltage received yet
+    }
+
+    auto now = this->now();
+    if ((now - last_voltage_time_).seconds() > stale_timout_)
+    {
+      RCLCPP_WARN(this->get_logger(), "Battery voltage data is stale!");
+      publishDiagnostics(0.0, true, true); // Publish critical status for stale data
+    }
+  }
+} // namespace rugged_rover_battery

--- a/rugged_rover_battery/src/main.cpp
+++ b/rugged_rover_battery/src/main.cpp
@@ -1,0 +1,14 @@
+#include "rugged_rover_battery/battery_voltage_monitor.hpp"
+
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+
+int main(int argc, char* argv[])
+{
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<rugged_rover_battery::BatteryVoltageMonitor>();
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+  return 0;
+}

--- a/rugged_rover_bringup/config/ekf.yaml
+++ b/rugged_rover_bringup/config/ekf.yaml
@@ -1,6 +1,6 @@
 ekf_filter_node:
   ros__parameters:
-    frequency: 50.0
+    frequency: 30.0
     sensor_timeout: 0.2
     two_d_mode: true
     transform_time_offset: 0.0
@@ -15,9 +15,11 @@ ekf_filter_node:
     base_link_frame: base_link
     world_frame: odom
 
-    odom0: /diff_drive_controller/odom
-    odom0_config: [false, false, false,
-                   false, false, false,
+    odom0: /odom_raw
+    # Fuse raw wheel odom pose and twist first. This should behave almost like
+    # diff_drive_controller odom, but keeps EKF in the pipeline for later IMU work.
+    odom0_config: [true,  true,  false,
+                   false, false, true,
                    true,  false, false,
                    false, false, true,
                    false, false, false]
@@ -27,19 +29,21 @@ ekf_filter_node:
     odom0_pose_rejection_threshold: 5.0
     odom0_twist_rejection_threshold: 2.0
 
-    imu0: /imu/data
-    imu0_config: [false, false, false,
-                  false, false, true,
-                  false, false, false,
-                  false, false, true,
-                  false, false, false]
-    imu0_queue_size: 10
-    imu0_differential: false
-    imu0_relative: true
-    imu0_pose_rejection_threshold: 1.0
-    imu0_twist_rejection_threshold: 1.0
-    imu0_linear_acceleration_rejection_threshold: 1.0
-    imu0_remove_gravitational_acceleration: false
+    # imu0: /imu/data
+    # # Start conservatively: use the IMU only for yaw velocity. Do not fuse
+    # # orientation until the Unity-to-ROS IMU frame/signs have been verified.
+    # imu0_config: [false, false, false,
+    #               false, false, false,
+    #               false, false, false,
+    #               false, false, false,
+    #               false, false, false]
+    # imu0_queue_size: 10
+    # imu0_differential: false
+    # imu0_relative: false
+    # imu0_pose_rejection_threshold: 1.0
+    # imu0_twist_rejection_threshold: 1.0
+    # imu0_linear_acceleration_rejection_threshold: 1.0
+    # imu0_remove_gravitational_acceleration: false
 
     process_noise_covariance: [0.05, 0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0,
                                0.0,  0.05, 0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0,

--- a/rugged_rover_bringup/config/ekf.yaml
+++ b/rugged_rover_bringup/config/ekf.yaml
@@ -18,8 +18,8 @@ ekf_filter_node:
     odom0: /odom_raw
     # Fuse raw wheel odom pose and twist first. This should behave almost like
     # diff_drive_controller odom, but keeps EKF in the pipeline for later IMU work.
-    odom0_config: [true,  true,  false,
-                   false, false, true,
+    odom0_config: [false,  false,  false,
+                   false, false, false,
                    true,  false, false,
                    false, false, true,
                    false, false, false]

--- a/rugged_rover_bringup/config/ekf.yaml
+++ b/rugged_rover_bringup/config/ekf.yaml
@@ -1,11 +1,11 @@
 ekf_filter_node:
   ros__parameters:
-    frequency: 30.0
+    frequency: 20.0
     sensor_timeout: 0.2
     two_d_mode: true
     transform_time_offset: 0.0
     transform_timeout: 0.1
-    print_diagnostics: true
+    print_diagnostics: false
     debug: false
     publish_tf: true
     publish_acceleration: false

--- a/rugged_rover_bringup/config/ekf.yaml
+++ b/rugged_rover_bringup/config/ekf.yaml
@@ -29,21 +29,19 @@ ekf_filter_node:
     odom0_pose_rejection_threshold: 5.0
     odom0_twist_rejection_threshold: 2.0
 
-    # imu0: /imu/data
-    # # Start conservatively: use the IMU only for yaw velocity. Do not fuse
-    # # orientation until the Unity-to-ROS IMU frame/signs have been verified.
-    # imu0_config: [false, false, false,
-    #               false, false, false,
-    #               false, false, false,
-    #               false, false, false,
-    #               false, false, false]
-    # imu0_queue_size: 10
-    # imu0_differential: false
-    # imu0_relative: false
-    # imu0_pose_rejection_threshold: 1.0
-    # imu0_twist_rejection_threshold: 1.0
-    # imu0_linear_acceleration_rejection_threshold: 1.0
-    # imu0_remove_gravitational_acceleration: false
+    imu0: /imu/data
+    imu0_config: [false, false, false,
+                  false, false, false,
+                  false, false, false,
+                  false, false, true,
+                  false, false, false]
+    imu0_queue_size: 10
+    imu0_differential: false
+    imu0_relative: false
+    imu0_pose_rejection_threshold: 1.0
+    imu0_twist_rejection_threshold: 1.0
+    imu0_linear_acceleration_rejection_threshold: 1.0
+    imu0_remove_gravitational_acceleration: false
 
     process_noise_covariance: [0.05, 0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0,
                                0.0,  0.05, 0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0,  0.0,

--- a/rugged_rover_bringup/config/slam_toolbox.yaml
+++ b/rugged_rover_bringup/config/slam_toolbox.yaml
@@ -12,7 +12,7 @@ slam_toolbox:
     transform_publish_period: 0.02
     map_update_interval: 1.0
     resolution: 0.05
-    max_laser_range: 12.0
+    max_laser_range: 30.0
     minimum_time_interval: 0.05
     transform_timeout: 0.3
     tf_buffer_duration: 30.0

--- a/rugged_rover_bringup/launch/bringup.launch.py
+++ b/rugged_rover_bringup/launch/bringup.launch.py
@@ -14,6 +14,7 @@ def generate_launch_description():
     rplidar_serial_port = LaunchConfiguration("rplidar_serial_port")
     rplidar_serial_baudrate = LaunchConfiguration("rplidar_serial_baudrate")
     use_slam = LaunchConfiguration("use_slam")
+    ekf_output_odom_topic = LaunchConfiguration("ekf_output_odom_topic")
 
     xacro_path = PathJoinSubstitution([
         FindPackageShare("rugged_rover_robot_description"),
@@ -90,6 +91,14 @@ def generate_launch_description():
             default_value="true",
             description="Launch slam_toolbox for live mapping.",
         ),
+        DeclareLaunchArgument(
+            "ekf_output_odom_topic",
+            default_value="/odom",
+            description=(
+                "Filtered EKF odometry topic. Set to /odom_raw when "
+                "ros2_fault_injection should publish the final /odom topic."
+            ),
+        ),
 
         Node(
             package="micro_ros_agent",
@@ -123,7 +132,7 @@ def generate_launch_description():
                 "use_sim_time": "false",
                 "odom_topic": "/diff_drive_controller/odom",
                 "imu_topic": "/imu/data",
-                "output_odom_topic": "/odom",
+                "output_odom_topic": ekf_output_odom_topic,
             }.items(),
         ),
 

--- a/rugged_rover_bringup/launch/bringup.launch.py
+++ b/rugged_rover_bringup/launch/bringup.launch.py
@@ -14,6 +14,7 @@ def generate_launch_description():
     rplidar_serial_port = LaunchConfiguration("rplidar_serial_port")
     rplidar_serial_baudrate = LaunchConfiguration("rplidar_serial_baudrate")
     use_slam = LaunchConfiguration("use_slam")
+    use_ekf = LaunchConfiguration("use_ekf")
     ekf_output_odom_topic = LaunchConfiguration("ekf_output_odom_topic")
 
     xacro_path = PathJoinSubstitution([
@@ -40,11 +41,11 @@ def generate_launch_description():
         "ekf.launch.py",
     ])
 
-    d435_launch = PathJoinSubstitution([
-        FindPackageShare("rugged_rover_bringup"),
-        "launch",
-        "d435.launch.py",
-    ])
+    # d435_launch = PathJoinSubstitution([
+    #     FindPackageShare("rugged_rover_bringup"),
+    #     "launch",
+    #     "d435.launch.py",
+    # ])
 
     rplidar_launch = PathJoinSubstitution([
         FindPackageShare("rugged_rover_bringup"),
@@ -92,6 +93,11 @@ def generate_launch_description():
             description="Launch slam_toolbox for live mapping.",
         ),
         DeclareLaunchArgument(
+            "use_ekf",
+            default_value="false",
+            description="Launch robot_localization EKF. Disable while validating raw wheel odom.",
+        ),
+        DeclareLaunchArgument(
             "ekf_output_odom_topic",
             default_value="/odom",
             description=(
@@ -128,6 +134,7 @@ def generate_launch_description():
 
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource(ekf_launch),
+            condition=IfCondition(use_ekf),
             launch_arguments={
                 "use_sim_time": "false",
                 "odom_topic": "/diff_drive_controller/odom",

--- a/rugged_rover_bringup/launch/bringup.launch.py
+++ b/rugged_rover_bringup/launch/bringup.launch.py
@@ -13,6 +13,7 @@ def generate_launch_description():
     use_rplidar = LaunchConfiguration("use_rplidar")
     rplidar_serial_port = LaunchConfiguration("rplidar_serial_port")
     rplidar_serial_baudrate = LaunchConfiguration("rplidar_serial_baudrate")
+    use_slam = LaunchConfiguration("use_slam")
 
     xacro_path = PathJoinSubstitution([
         FindPackageShare("rugged_rover_robot_description"),
@@ -50,6 +51,12 @@ def generate_launch_description():
         "rplidar_s2.launch.py",
     ])
 
+    slam_launch = PathJoinSubstitution([
+        FindPackageShare("rugged_rover_bringup"),
+        "launch",
+        "slam.launch.py",
+    ])
+
     robot_description = {
         "robot_description": ParameterValue(
             Command(["xacro ", xacro_path]),
@@ -77,6 +84,11 @@ def generate_launch_description():
             "rplidar_serial_baudrate",
             default_value="1000000",
             description="Serial baudrate used by the RPLIDAR S2.",
+        ),
+        DeclareLaunchArgument(
+            "use_slam",
+            default_value="true",
+            description="Launch slam_toolbox for live mapping.",
         ),
 
         Node(
@@ -127,6 +139,14 @@ def generate_launch_description():
                 "serial_baudrate": rplidar_serial_baudrate,
                 "frame_id": "laser",
                 "scan_topic": "/scan",
+            }.items(),
+        ),
+
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(slam_launch),
+            condition=IfCondition(use_slam),
+            launch_arguments={
+                "use_sim_time": "false",
             }.items(),
         ),
 

--- a/rugged_rover_bringup/launch/bringup.launch.py
+++ b/rugged_rover_bringup/launch/bringup.launch.py
@@ -1,5 +1,6 @@
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, TimerAction
+from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import Command, LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
@@ -9,6 +10,9 @@ from launch_ros.substitutions import FindPackageShare
 
 def generate_launch_description():
     micro_ros_device = LaunchConfiguration("micro_ros_device")
+    use_rplidar = LaunchConfiguration("use_rplidar")
+    rplidar_serial_port = LaunchConfiguration("rplidar_serial_port")
+    rplidar_serial_baudrate = LaunchConfiguration("rplidar_serial_baudrate")
 
     xacro_path = PathJoinSubstitution([
         FindPackageShare("rugged_rover_robot_description"),
@@ -40,6 +44,12 @@ def generate_launch_description():
         "d435.launch.py",
     ])
 
+    rplidar_launch = PathJoinSubstitution([
+        FindPackageShare("rugged_rover_bringup"),
+        "launch",
+        "rplidar_s2.launch.py",
+    ])
+
     robot_description = {
         "robot_description": ParameterValue(
             Command(["xacro ", xacro_path]),
@@ -52,6 +62,21 @@ def generate_launch_description():
             "micro_ros_device",
             default_value="/dev/ttyAMA0",
             description="Serial device used by the micro-ROS Agent.",
+        ),
+        DeclareLaunchArgument(
+            "use_rplidar",
+            default_value="true",
+            description="Launch the RPLIDAR S2 driver.",
+        ),
+        DeclareLaunchArgument(
+            "rplidar_serial_port",
+            default_value="/dev/rplidar",
+            description="Serial device used by the RPLIDAR S2.",
+        ),
+        DeclareLaunchArgument(
+            "rplidar_serial_baudrate",
+            default_value="1000000",
+            description="Serial baudrate used by the RPLIDAR S2.",
         ),
 
         Node(
@@ -92,6 +117,17 @@ def generate_launch_description():
 
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource(d435_launch),
+        ),
+
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(rplidar_launch),
+            condition=IfCondition(use_rplidar),
+            launch_arguments={
+                "serial_port": rplidar_serial_port,
+                "serial_baudrate": rplidar_serial_baudrate,
+                "frame_id": "laser",
+                "scan_topic": "/scan",
+            }.items(),
         ),
 
         Node(

--- a/rugged_rover_bringup/launch/bringup.launch.py
+++ b/rugged_rover_bringup/launch/bringup.launch.py
@@ -143,9 +143,9 @@ def generate_launch_description():
             }.items(),
         ),
 
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource(d435_launch),
-        ),
+        # IncludeLaunchDescription(
+        #     PythonLaunchDescriptionSource(d435_launch),
+        # ),
 
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource(rplidar_launch),

--- a/rugged_rover_bringup/launch/bringup.launch.py
+++ b/rugged_rover_bringup/launch/bringup.launch.py
@@ -63,6 +63,13 @@ def generate_launch_description():
         ),
 
         Node(
+            package="rugged_rover_battery",
+            executable="battery_voltage_monitor",
+            name="battery_voltage_monitor",
+            output="screen",
+        ),
+
+        Node(
             package="robot_state_publisher",
             executable="robot_state_publisher",
             output="screen",

--- a/rugged_rover_bringup/launch/d435.launch.py
+++ b/rugged_rover_bringup/launch/d435.launch.py
@@ -24,7 +24,7 @@ def generate_launch_description():
                 'enable_depth': 'true',
                 'enable_sync': 'true',
                 'align_depth.enable': 'true',
-                'pointcloud.enable': 'true',
+                'pointcloud.enable': 'false',
                 'publish_tf': 'true',
                 'tf_publish_rate': '0.0',
             }.items(),
@@ -36,14 +36,14 @@ def generate_launch_description():
             output='screen',
             parameters=[{
                 'output_frame': 'camera_depth_frame',
-                'range_min': 0.25,
-                'range_max': 4.0,
-                'scan_height': 10,
+                'range_min': 0.15,
+                'range_max': 2.0,
+                'scan_height': 4,
             }],
             remappings=[
                 ('depth', '/camera/camera/depth/image_rect_raw'),
                 ('depth_camera_info', '/camera/camera/depth/camera_info'),
-                ('scan', '/scan'),
+                ('scan', '/depth_scan'),
             ],
         ),
     ])

--- a/rugged_rover_bringup/launch/rplidar_s2.launch.py
+++ b/rugged_rover_bringup/launch/rplidar_s2.launch.py
@@ -45,7 +45,7 @@ def generate_launch_description():
                 "frame_id": frame_id,
                 "inverted": False,
                 "angle_compensate": True,
-                "scan_mode": "DenseBoost",
+                "scan_mode": "",
             }],
             remappings=[
                 ("scan", scan_topic),

--- a/rugged_rover_bringup/launch/rplidar_s2.launch.py
+++ b/rugged_rover_bringup/launch/rplidar_s2.launch.py
@@ -1,0 +1,53 @@
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    serial_port = LaunchConfiguration("serial_port")
+    serial_baudrate = LaunchConfiguration("serial_baudrate")
+    frame_id = LaunchConfiguration("frame_id")
+    scan_topic = LaunchConfiguration("scan_topic")
+
+    return LaunchDescription([
+        DeclareLaunchArgument(
+            "serial_port",
+            default_value="/dev/rplidar",
+            description="Serial device for the RPLIDAR S2.",
+        ),
+        DeclareLaunchArgument(
+            "serial_baudrate",
+            default_value="1000000",
+            description="Serial baudrate for the RPLIDAR S2.",
+        ),
+        DeclareLaunchArgument(
+            "frame_id",
+            default_value="laser",
+            description="Frame id used in LaserScan messages.",
+        ),
+        DeclareLaunchArgument(
+            "scan_topic",
+            default_value="/scan",
+            description="LaserScan topic name.",
+        ),
+
+        Node(
+            package="sllidar_ros2",
+            executable="sllidar_node",
+            name="rplidar_s2",
+            output="screen",
+            parameters=[{
+                "channel_type": "serial",
+                "serial_port": serial_port,
+                "serial_baudrate": serial_baudrate,
+                "frame_id": frame_id,
+                "inverted": False,
+                "angle_compensate": True,
+                "scan_mode": "DenseBoost",
+            }],
+            remappings=[
+                ("scan", scan_topic),
+            ],
+        ),
+    ])

--- a/rugged_rover_bringup/launch/rplidar_s2.launch.py
+++ b/rugged_rover_bringup/launch/rplidar_s2.launch.py
@@ -2,6 +2,7 @@ from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
 
 
 def generate_launch_description():
@@ -40,7 +41,7 @@ def generate_launch_description():
             parameters=[{
                 "channel_type": "serial",
                 "serial_port": serial_port,
-                "serial_baudrate": serial_baudrate,
+                "serial_baudrate": ParameterValue(serial_baudrate, value_type=int),
                 "frame_id": frame_id,
                 "inverted": False,
                 "angle_compensate": True,

--- a/rugged_rover_bringup/launch/slam.launch.py
+++ b/rugged_rover_bringup/launch/slam.launch.py
@@ -18,8 +18,8 @@ def generate_launch_description():
     return LaunchDescription([
         DeclareLaunchArgument(
             "use_sim_time",
-            default_value="true",
-            description="Use Unity /clock for slam_toolbox.",
+            default_value="false",
+            description="Use simulated /clock for slam_toolbox.",
         ),
 
         Node(

--- a/rugged_rover_bringup/launch/slam.launch.py
+++ b/rugged_rover_bringup/launch/slam.launch.py
@@ -42,7 +42,9 @@ def generate_launch_description():
                         "-lc",
                         "until ros2 service list | grep -q '^/slam_toolbox/change_state$'; "
                         "do sleep 0.2; done; "
-                        "ros2 lifecycle set /slam_toolbox configure",
+                        "ros2 service call /slam_toolbox/change_state "
+                        "lifecycle_msgs/srv/ChangeState "
+                        "'{transition: {id: 1}}'",
                     ],
                     output="screen",
                 ),
@@ -56,9 +58,13 @@ def generate_launch_description():
                     cmd=[
                         "bash",
                         "-lc",
-                        "until ros2 lifecycle get /slam_toolbox 2>/dev/null | grep -q 'inactive'; "
+                        "until ros2 service call /slam_toolbox/get_state "
+                        "lifecycle_msgs/srv/GetState "
+                        "'{}' 2>/dev/null | grep -Eq 'id=2|id: 2'; "
                         "do sleep 0.2; done; "
-                        "ros2 lifecycle set /slam_toolbox activate",
+                        "ros2 service call /slam_toolbox/change_state "
+                        "lifecycle_msgs/srv/ChangeState "
+                        "'{transition: {id: 3}}'",
                     ],
                     output="screen",
                 ),

--- a/rugged_rover_bringup/launch/unity_sim.launch.py
+++ b/rugged_rover_bringup/launch/unity_sim.launch.py
@@ -30,7 +30,7 @@ def generate_launch_description():
 
     robot_description = {
         "robot_description": ParameterValue(
-            Command(["xacro ", xacro_path]),
+            Command(["xacro ", xacro_path, " command_qos:=reliable"]),
             value_type=str,
         )
     }

--- a/rugged_rover_bringup/launch/unity_sim.launch.py
+++ b/rugged_rover_bringup/launch/unity_sim.launch.py
@@ -67,11 +67,16 @@ def generate_launch_description():
 
                 # Unity is the upstream motor feedback producer. Route it through
                 # fault injection before ros2_control consumes it.
-                ("/platform/motors/feedback", "/platform/motors/feedback_raw"),
+                # ("/platform/motors/feedback", "/platform/motors/feedback_raw"),
             ],
             output="screen",
         ),
-
+        Node(
+            package="rugged_rover_battery",
+            executable="battery_voltage_monitor",
+            name="battery_voltage_monitor",
+            output="screen",
+        ),
         Node(
             package="robot_state_publisher",
             executable="robot_state_publisher",
@@ -79,7 +84,6 @@ def generate_launch_description():
             parameters=[robot_description, {"use_sim_time": True}],
             output="screen",
         ),
-
         Node(
             package="controller_manager",
             executable="ros2_control_node",
@@ -90,9 +94,8 @@ def generate_launch_description():
                 {"use_sim_time": True},
             ],
             remappings=[
-                # diff_drive_controller publishes wheel-derived odometry under the
-                # controller namespace. Fault injection consumes /odom_raw and
-                # republishes the possibly faulted stream on /odom for Nav2/SLAM.
+                # Feed wheel-derived odometry into EKF. EKF republishes the
+                # fused odometry on /odom and owns odom -> base_link.
                 ("/diff_drive_controller/odom", "/odom_raw"),
             ],
             output="screen",
@@ -118,10 +121,19 @@ def generate_launch_description():
                         "joint_state_broadcaster",
                         "--controller-manager",
                         "/controller_manager",
-                        "--activate",
+                        "--controller-manager-timeout",
+                        "20",
+                        "--switch-timeout",
+                        "20",
                     ],
                     output="screen",
                 ),
+            ],
+        ),
+
+        TimerAction(
+            period=6.0,
+            actions=[
                 Node(
                     package="controller_manager",
                     executable="spawner",
@@ -129,7 +141,10 @@ def generate_launch_description():
                         "diff_drive_controller",
                         "--controller-manager",
                         "/controller_manager",
-                        "--activate",
+                        "--controller-manager-timeout",
+                        "20",
+                        "--switch-timeout",
+                        "20",
                     ],
                     output="screen",
                 ),

--- a/rugged_rover_bringup/launch/unity_sim.launch.py
+++ b/rugged_rover_bringup/launch/unity_sim.launch.py
@@ -1,7 +1,7 @@
 from launch import LaunchDescription
-from launch.actions import IncludeLaunchDescription, TimerAction
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, TimerAction
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import Command, PathJoinSubstitution
+from launch.substitutions import Command, LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
 from launch_ros.parameter_descriptions import ParameterValue
 from launch_ros.substitutions import FindPackageShare
@@ -9,6 +9,10 @@ from launch_ros.substitutions import FindPackageShare
 
 def generate_launch_description():
     description_pkg = FindPackageShare("rugged_rover_robot_description")
+    wheel_odom_topic = LaunchConfiguration("wheel_odom_topic")
+    ekf_output_odom_topic = LaunchConfiguration("ekf_output_odom_topic")
+    ros_tcp_ip = LaunchConfiguration("ros_tcp_ip")
+    ros_tcp_port = LaunchConfiguration("ros_tcp_port")
 
     xacro_path = PathJoinSubstitution([
         description_pkg,
@@ -50,13 +54,41 @@ def generate_launch_description():
     }
 
     return LaunchDescription([
+        DeclareLaunchArgument(
+            "wheel_odom_topic",
+            default_value="/odom_raw",
+            description=(
+                "Wheel odometry topic produced by diff_drive_controller and "
+                "consumed by the EKF. Use /wheel/odom_raw when the EKF output "
+                "is remapped to /odom_raw for fault injection."
+            ),
+        ),
+        DeclareLaunchArgument(
+            "ekf_output_odom_topic",
+            default_value="/odom",
+            description=(
+                "Filtered EKF odometry topic. Set to /odom_raw when "
+                "ros2_fault_injection should publish the final /odom topic."
+            ),
+        ),
+        DeclareLaunchArgument(
+            "ros_tcp_ip",
+            default_value="0.0.0.0",
+            description="Address for ros_tcp_endpoint to bind to. Use 0.0.0.0 for remote Unity clients.",
+        ),
+        DeclareLaunchArgument(
+            "ros_tcp_port",
+            default_value="10000",
+            description="Port for ros_tcp_endpoint.",
+        ),
+
         Node(
             package="ros_tcp_endpoint",
             executable="default_server_endpoint",
             name="ros_tcp_endpoint",
             parameters=[{
-                "ROS_IP": "127.0.0.1",
-                "ROS_TCP_PORT": 10000,
+                "ROS_IP": ros_tcp_ip,
+                "ROS_TCP_PORT": ParameterValue(ros_tcp_port, value_type=int),
             }],
             remappings=[
                 # Keep Unity's pose estimate available for comparison, but do not let
@@ -96,7 +128,7 @@ def generate_launch_description():
             remappings=[
                 # Feed wheel-derived odometry into EKF. EKF republishes the
                 # fused odometry on /odom and owns odom -> base_link.
-                ("/diff_drive_controller/odom", "/odom_raw"),
+                ("/diff_drive_controller/odom", wheel_odom_topic),
             ],
             output="screen",
         ),
@@ -105,9 +137,9 @@ def generate_launch_description():
             PythonLaunchDescriptionSource(ekf_launch),
             launch_arguments={
                 "use_sim_time": "true",
-                "odom_topic": "/odom_raw",
+                "odom_topic": wheel_odom_topic,
                 "imu_topic": "/imu/data",
-                "output_odom_topic": "/odom",
+                "output_odom_topic": ekf_output_odom_topic,
             }.items(),
         ),
 

--- a/rugged_rover_control/config/controllers.yaml
+++ b/rugged_rover_control/config/controllers.yaml
@@ -1,6 +1,6 @@
 controller_manager:
   ros__parameters:
-    update_rate: 100
+    update_rate: 30
     hardware_platform:
       type: "rugged_rover_hardware_interfaces/sabertooth/SabertoothSystemInterface"
       joints:
@@ -23,10 +23,12 @@ diff_drive_controller:
   ros__parameters:
     left_wheel_names: ["front_left_joint", "rear_left_joint"]
     right_wheel_names: ["front_right_joint", "rear_right_joint"]
-    wheel_separation: 0.27
-    wheel_radius: 0.065
+    # Effective skid-steer track width calibrated from 360 degree rotation test.
+    # Physical rear wheel center distance is ~0.355 m.
+    wheel_separation: 0.652
+    wheel_radius: 0.060
     use_stamped_vel: false
     base_frame_id: base_link
     cmd_vel_timeout: 0.25
-    publish_rate: 50.0
-    enable_odom_tf: false
+    publish_rate: 30.0
+    enable_odom_tf: true

--- a/rugged_rover_hardware_interfaces/include/rugged_rover_hardware_interfaces/sabertooth/sabertooth_system_interface.hpp
+++ b/rugged_rover_hardware_interfaces/include/rugged_rover_hardware_interfaces/sabertooth/sabertooth_system_interface.hpp
@@ -4,6 +4,7 @@
 #define RUGGED_ROVER_HARDWARE_INTERFACES_SABERTOOTH_SYSTEM_INTERFACE_HPP
 
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -62,6 +63,9 @@ namespace rugged_rover_hardware_interfaces::sabertooth
     rclcpp::Logger logger_ = rclcpp::get_logger("SabertoothSystemInterface");
 
     sensor_msgs::msg::JointState last_feedback_;
+    rclcpp::Time last_feedback_time_;
+    bool has_feedback_ = false;
+    double feedback_timeout_seconds_ = 0.25;
     std::mutex feedback_mutex_;
 
     friend class SabertoothInterfaceTest;

--- a/rugged_rover_hardware_interfaces/include/rugged_rover_hardware_interfaces/sabertooth/sabertooth_system_interface.hpp
+++ b/rugged_rover_hardware_interfaces/include/rugged_rover_hardware_interfaces/sabertooth/sabertooth_system_interface.hpp
@@ -12,6 +12,7 @@
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/joint_state.hpp"
+#include "std_msgs/msg/bool.hpp"
 
 namespace rugged_rover_hardware_interfaces::sabertooth
 {
@@ -51,6 +52,8 @@ namespace rugged_rover_hardware_interfaces::sabertooth
 
     rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr feedback_sub_;
 
+    rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr battery_critical_sub_;
+
     rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr cmd_pub_;
 
     void feedbackCallback(const sensor_msgs::msg::JointState::SharedPtr msg);
@@ -66,7 +69,11 @@ namespace rugged_rover_hardware_interfaces::sabertooth
     rclcpp::Time last_feedback_time_;
     bool has_feedback_ = false;
     double feedback_timeout_seconds_ = 0.25;
+    bool use_reliable_command_qos_ = false;
+    rclcpp::Time last_command_publish_time_;
+    double command_publish_period_seconds_ = 0.05;
     std::mutex feedback_mutex_;
+    std::atomic<bool> battery_allows_motion_ = true;
 
     friend class SabertoothInterfaceTest;
   };

--- a/rugged_rover_hardware_interfaces/package.xml
+++ b/rugged_rover_hardware_interfaces/package.xml
@@ -9,17 +9,15 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>pluginlib</build_depend>
-
-  <build_export_depend>pluginlib</build_export_depend>
-
-  <exec_depend>pluginlib</exec_depend>
-  <exec_depend>hardware_interface</exec_depend>
+  <depend>rclcpp</depend>
+  <depend>hardware_interface</depend>
+  <depend>controller_interface</depend>
+  <depend>pluginlib</depend>
+  <depend>rugged_rover_interfaces</depend>
   
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 
-  <depend>rugged_rover_interfaces</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rugged_rover_hardware_interfaces/src/sabertooth/sabertooth_system_interface.cpp
+++ b/rugged_rover_hardware_interfaces/src/sabertooth/sabertooth_system_interface.cpp
@@ -1,5 +1,6 @@
 #include "rugged_rover_hardware_interfaces/sabertooth/sabertooth_system_interface.hpp"
 
+#include <algorithm>
 #include <string>
 #include <vector>
 
@@ -174,6 +175,18 @@ namespace rugged_rover_hardware_interfaces::sabertooth
 
     std::lock_guard<std::mutex> lock(feedback_mutex_);
 
+    // If Unity or the Teensy stops publishing feedback, do not keep replaying
+    // the last non-zero velocity forever. Keep the last positions, but report
+    // zero wheel velocity so odometry stops advancing in RViz.
+    const bool feedback_is_stale =
+        !has_feedback_ || !node_ ||
+        (node_->now() - last_feedback_time_).seconds() > feedback_timeout_seconds_;
+    if (feedback_is_stale)
+    {
+      std::fill(hw_velocities_.begin(), hw_velocities_.end(), 0.0);
+      return hardware_interface::return_type::OK;
+    }
+
     // Update positions and velocities from the most recent feedback
     for (size_t i = 0; i < joint_names_.size(); ++i)
     {
@@ -253,6 +266,8 @@ namespace rugged_rover_hardware_interfaces::sabertooth
 
     // Update the last_feedback_ member variable with the received message
     last_feedback_ = *msg;
+    last_feedback_time_ = node_->now();
+    has_feedback_ = true;
   }
 
 } // namespace rugged_rover_hardware_interfaces::sabertooth

--- a/rugged_rover_hardware_interfaces/src/sabertooth/sabertooth_system_interface.cpp
+++ b/rugged_rover_hardware_interfaces/src/sabertooth/sabertooth_system_interface.cpp
@@ -40,6 +40,12 @@ namespace rugged_rover_hardware_interfaces::sabertooth
       joint_names_.push_back(joint.name);
     }
 
+    const auto command_qos = info.hardware_parameters.find("command_qos");
+    if (command_qos != info.hardware_parameters.end())
+    {
+      use_reliable_command_qos_ = command_qos->second == "reliable";
+    }
+
     // Resize the hardware state and command vectors to match the number of joints
     hw_positions_.resize(joint_names_.size(), 0.0);
     hw_velocities_.resize(joint_names_.size(), 0.0);
@@ -73,9 +79,31 @@ namespace rugged_rover_hardware_interfaces::sabertooth
         "platform/motors/feedback", rclcpp::SensorDataQoS(),
         std::bind(&SabertoothSystemInterface::feedbackCallback, this, std::placeholders::_1));
 
-    // Create a publisher for the command topic
+    battery_critical_sub_ = node_->create_subscription<std_msgs::msg::Bool>(
+        "platform/battery/is_critical", rclcpp::SensorDataQoS(),
+        [this](const std_msgs::msg::Bool::SharedPtr msg)
+        { battery_allows_motion_.store(!msg->data); });
+
+    // Motor commands should be "latest value wins". The real rover uses
+    // best-effort so old velocity commands are dropped instead of replayed late.
+    // Unity's ROS TCP endpoint subscribes reliably, so simulation opts into
+    // reliable QoS through the command_qos hardware parameter.
+    auto command_qos = rclcpp::QoS(rclcpp::KeepLast(1));
+    if (use_reliable_command_qos_)
+    {
+      command_qos.reliable();
+    }
+    else
+    {
+      command_qos.best_effort();
+    }
+
+    RCLCPP_INFO(this->logger_, "Using %s QoS for platform motor commands",
+                use_reliable_command_qos_ ? "reliable" : "best_effort");
+
     cmd_pub_ = node_->create_publisher<sensor_msgs::msg::JointState>("platform/motors/cmd",
-                                                                     rclcpp::QoS(10).reliable());
+                                                                     command_qos);
+    last_command_publish_time_ = node_->now();
 
     // Return success if activation is complete
     return hardware_interface::CallbackReturn::SUCCESS;
@@ -99,6 +127,7 @@ namespace rugged_rover_hardware_interfaces::sabertooth
 
     // Reset the node, subscription, and publisher to clean up resources
     feedback_sub_.reset();
+    battery_critical_sub_.reset();
     cmd_pub_.reset();
     node_.reset();
 
@@ -231,15 +260,30 @@ namespace rugged_rover_hardware_interfaces::sabertooth
       RCLCPP_ERROR(this->logger_, "Command publisher or node is not initialized.");
       return hardware_interface::return_type::ERROR;
     }
+    const rclcpp::Time now = node_->now();
+    if ((now - last_command_publish_time_).seconds() < command_publish_period_seconds_)
+    {
+      return hardware_interface::return_type::OK;
+    }
+    last_command_publish_time_ = now;
+
     // Create a JointState message to publish the commands
     sensor_msgs::msg::JointState cmd_msg;
 
     // Set the header for the command message
-    cmd_msg.header.stamp = node_->now();
+    cmd_msg.header.stamp = now;
 
     // Set the joint names and commands in the command message
     cmd_msg.name = joint_names_;
-    cmd_msg.velocity = hw_commands_;
+
+    if (!battery_allows_motion_.load())
+    {
+      cmd_msg.velocity.assign(joint_names_.size(), 0.0);
+    }
+    else
+    {
+      cmd_msg.velocity = hw_commands_;
+    }
 
     // Publish the command message to the topic
 

--- a/rugged_rover_robot_description/urdf/rugged_rover.urdf.xacro
+++ b/rugged_rover_robot_description/urdf/rugged_rover.urdf.xacro
@@ -169,7 +169,7 @@
   <joint name="base_to_laser" type="fixed">
     <parent link="base_link"/>
     <child link="laser"/>
-    <origin xyz="0.122 0 0.1656" rpy="0 0 0"/>
+    <origin xyz="0 0 ${chassis_bottom_z_offset + 0.190}" rpy="0 0 0"/>
   </joint>
 
   <link name="imu_link"/>

--- a/rugged_rover_robot_description/urdf/rugged_rover.urdf.xacro
+++ b/rugged_rover_robot_description/urdf/rugged_rover.urdf.xacro
@@ -150,11 +150,11 @@
     </visual>
   </link>
 
-  <joint name="base_to_camera" type="fixed">
-    <parent link="base_link"/>
-    <child link="camera_link"/>
-    <origin xyz="0.280 0 0.320" rpy="0 0.261799 0"/>
-  </joint>
+<joint name="base_to_camera" type="fixed">
+  <parent link="base_link"/>
+  <child link="camera_link"/>
+  <origin xyz="0.150 0 ${chassis_bottom_z_offset + 0.090}" rpy="0 0 0"/>
+</joint>
 
   <link name="laser">
     <visual>
@@ -169,7 +169,7 @@
   <joint name="base_to_laser" type="fixed">
     <parent link="base_link"/>
     <child link="laser"/>
-    <origin xyz="0 0 ${chassis_bottom_z_offset + 0.190}" rpy="0 0 0"/>
+    <origin xyz="0 0 ${chassis_bottom_z_offset + 0.190}" rpy="0 0 3.14159265359"/>
   </joint>
 
   <link name="imu_link"/>

--- a/rugged_rover_robot_description/urdf/rugged_rover.urdf.xacro
+++ b/rugged_rover_robot_description/urdf/rugged_rover.urdf.xacro
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro" name="rugged_rover">
+  <xacro:arg name="command_qos" default="best_effort"/>
 
   <!-- Dimensions are in meters. ROS convention: X forward, Y left, Z up. -->
   <xacro:property name="chassis_length" value="0.320"/>
@@ -182,6 +183,7 @@
   <ros2_control name="RuggedRoverControl" type="system">
     <hardware>
       <plugin>rugged_rover_hardware_interfaces/sabertooth/SabertoothSystemInterface</plugin>
+      <param name="command_qos">$(arg command_qos)</param>
     </hardware>
 
     <joint name="front_left_joint">


### PR DESCRIPTION
# Add RPLIDAR S2 bringup

## Summary

Adds initial ROS 2 bringup support for the RPLIDAR S2 on the rugged rover.

This introduces a dedicated launch path for the S2 lidar so it can publish `/scan` from the real rover hardware and be used with RViz, SLAM Toolbox, and Nav2.

## Changes

- Added RPLIDAR S2 launch support
- Configured the SLLIDAR ROS 2 node for the rover lidar
- Remapped the lidar scan output to `/scan`
- Added launch arguments for serial port and lidar startup behavior
- Added support for retrying after lidar health-check failures
- Added optional motor-start-before-health-check behavior for debugging S2 startup issues
- Updated rover bringup expectations around using the physical lidar instead of simulated/depth-camera scan data

## Motivation

The rover now has a physical RPLIDAR S2 mounted on the chassis, so the ROS stack needs a proper hardware bringup path for 2D lidar data.

This is needed before tuning real-world SLAM and Nav2, since the Unity scan and D435-derived scan are not representative of the final hardware layout.

## Testing

Tested on the rover Raspberry Pi with the RPLIDAR S2 connected over USB.

Verified:

- SLLIDAR node launches
- Device is detected over serial
- Lidar serial number, firmware version, and hardware revision are read
- `/scan` can be produced once the Pi power issue is resolved
- Power instability was identified as the cause of repeated S2 health status errors

## Notes

During testing, the lidar reported health status `2` when the Raspberry Pi supply was undervolting. Powering the Pi from a proper USB-C supply cleared the lidar fault, confirming this was a power delivery issue rather than a ROS launch issue.

The D435 depth-to-laserscan path should be disabled or remapped when using the physical RPLIDAR as the main `/scan` source.