### PR TITLE
Rugged Rover Bringup, Tuning, and Pi Bootstrap Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,91 +1,132 @@
 # Rugged Rover
 
-Rugged Rover is a ROS 2 Jazzy rover stack for the Lynxmotion A4WD3 platform. It supports both the real rover hardware path and a Unity simulation path, using the same robot description, ros2_control controllers, and navigation stack where possible.
+Rugged Rover is a ROS 2 Jazzy stack for a Lynxmotion A4WD3 skid-steer rover. The
+current target platform is a Raspberry Pi 5 running Ubuntu Server 24.04, with a
+Teensy 4.1 handling the motor controller, encoder feedback, battery monitoring,
+and micro-ROS transport.
 
-The current system is built around:
+The stack supports:
 
-- ROS 2 Jazzy on Ubuntu 24.04
-- `ros2_control` with a custom Sabertooth hardware interface
-- Teensy 4.1 firmware using micro-ROS for motor command and encoder feedback
-- A4WD3 chassis and wheel meshes in the URDF
-- Unity simulation through `ros_tcp_endpoint`
-- SLAM Toolbox, Nav2, RViz, and differential drive control
+- `ros2_control` differential drive control
+- Teensy 4.1 + Sabertooth motor control over micro-ROS
+- A4WD3 URDF with chassis, wheel, lidar, camera, and IMU frames
+- RPLIDAR S2 laser scans
+- SparkFun Razor IMU
+- Intel RealSense D435 depth camera support
+- SLAM Toolbox mapping
+- Nav2 autonomous navigation
+- Unity simulation support through `ros_tcp_endpoint`
 
 ## Repository Layout
 
 | Path | Purpose |
 | --- | --- |
-| `rugged_rover_bringup` | Hardware, Unity sim, SLAM, and Nav2 launch files plus shared configs. |
-| `rugged_rover_robot_description` | Xacro/URDF, meshes, RViz configs, and robot visualization launches. |
-| `rugged_rover_hardware_interfaces` | Custom `ros2_control` system interface that bridges controller commands to `/platform/motors/cmd` and reads `/platform/motors/feedback`. |
-| `rugged_rover_control` | Controller configuration and standalone control launch support. |
+| `rugged_rover_bringup` | Real rover, Unity sim, SLAM, Nav2, joystick, lidar, camera, and EKF launch files. |
+| `rugged_rover_robot_description` | Xacro/URDF, meshes, RViz configs, and robot visualization launch files. |
+| `rugged_rover_control` | `ros2_control` controller configuration. |
+| `rugged_rover_hardware_interfaces` | Custom Sabertooth `ros2_control` hardware interface. |
+| `rugged_rover_battery` | Battery voltage monitor and diagnostics node. |
 | `rugged_rover_interfaces` | Custom message and service definitions. |
-| `rugged_rover_test` | Small test publishers for command and joint-state experiments. |
-| `micro_ros_platform_firmware` | Teensy 4.1 firmware for Sabertooth motor control, encoder feedback, and micro-ROS communication. |
+| `rugged_rover_test` | Small command/test publishers. |
+| `micro_ros_platform_firmware` | Teensy firmware for the A4WD3 platform. |
 | `micro_ros_agent` | micro-ROS Agent submodule. |
+| `rugged_rover_imu` | Razor IMU ROS 2 driver and firmware submodule. |
+| `sllidar_ros2` | Slamtec RPLIDAR ROS 2 driver submodule. |
+| `rugged_rover_bootstrap` | Raspberry Pi 5 bootstrap installer for Ubuntu 24.04, ROS 2 Jazzy, udev rules, and workspace setup. |
 
-## Main ROS Topics
+## Hardware Baseline
 
-| Topic | Type | Direction | Notes |
-| --- | --- | --- | --- |
-| `/platform/motors/cmd` | `sensor_msgs/msg/JointState` | ROS -> Teensy/Unity | Wheel velocity commands from the hardware interface. |
-| `/platform/motors/feedback` | `sensor_msgs/msg/JointState` | Teensy/Unity -> ROS | Wheel position and velocity feedback consumed by `ros2_control`. |
-| `/joint_states` | `sensor_msgs/msg/JointState` | ROS | Published by `joint_state_broadcaster`. |
-| `/diff_drive_controller/cmd_vel` | `geometry_msgs/msg/TwistStamped` | Nav2/manual -> controller | Command input for the Jazzy diff drive controller. |
-| `/diff_drive_controller/odom` | `nav_msgs/msg/Odometry` | ROS | Wheel odometry from `diff_drive_controller`. |
-| `/scan` | `sensor_msgs/msg/LaserScan` | Sensor/sim -> SLAM/Nav2 | 2D lidar scan input. |
-| `/clock` | `rosgraph_msgs/msg/Clock` | Unity -> ROS | Required when running the Unity simulation with `use_sim_time`. |
-| `/tf`, `/tf_static` | `tf2_msgs/msg/TFMessage` | ROS | Robot, odom, map, and sensor transforms. |
+The current A4WD3 setup assumes:
 
-## Prerequisites
+- Raspberry Pi 5 running Ubuntu Server 24.04
+- ROS 2 Jazzy
+- Teensy 4.1
+- Sabertooth motor driver
+- A4WD3 motors with 51:1 gearbox and quadrature encoders
+- RPLIDAR S2 on `/dev/rplidar`
+- SparkFun Razor IMU on `/dev/razor_imu`
+- Teensy micro-ROS UART on `/dev/ttyAMA0`
+- Optional RealSense D435 depth camera
+- Common ground between the Pi, Teensy, motor driver, battery monitor, and motor power system
 
-Install ROS 2 Jazzy and the rover dependencies on Ubuntu 24.04:
+The controller calibration currently uses:
 
-```bash
-sudo apt update
-sudo apt install -y \
-  python3-colcon-common-extensions \
-  python3-rosdep \
-  python3-vcstool \
-  ros-jazzy-ros2-control \
-  ros-jazzy-ros2-controllers \
-  ros-jazzy-controller-manager \
-  ros-jazzy-joint-state-broadcaster \
-  ros-jazzy-diff-drive-controller \
-  ros-jazzy-xacro \
-  ros-jazzy-robot-state-publisher \
-  ros-jazzy-rviz2 \
-  ros-jazzy-slam-toolbox \
-  ros-jazzy-navigation2 \
-  ros-jazzy-nav2-bringup \
-  ros-jazzy-topic-tools
+```yaml
+wheel_separation: 0.475
+wheel_radius: 0.082
 ```
 
-Initialize `rosdep` once if needed:
+These are effective odometry values, not simply the measured wheel-to-wheel
+distance. The physical rear wheel center-to-center distance is about `0.355 m`,
+but the skid-steer odometry needed a larger effective separation after rotation
+testing.
+
+## Fresh Raspberry Pi 5 Setup
+
+Start from Ubuntu Server 24.04 on the Raspberry Pi 5. SSH into the Pi, then run:
 
 ```bash
-sudo rosdep init
-rosdep update
+git clone --branch support-unity-sim git@github.com:reeceholland/rugged_rover.git ~/rugged_rover_bootstrap
+cd ~/rugged_rover_bootstrap
+bash rugged_rover_bootstrap/install_pi5_ubuntu24_ros_jazzy.sh
 ```
 
-## Clone and Build
+The installer:
+
+- repairs the Ubuntu noble-updates apt source if it is missing
+- installs bzip2/libbz2 after the apt source repair
+- installs ROS 2 Jazzy and rover dependencies
+- configures the ROS apt repository
+- configures rosdep
+- clones this repository into ~/rugged_rover_ws/src/rugged_rover
+- initializes submodules
+- creates udev aliases for the Teensy UART, RPLIDAR, and Razor IMU
+- builds the workspace
+- adds ROS setup lines to ~/.bashrc
+
+After the script finishes, reboot:
+
+```bash
+sudo reboot
+```
+
+Reconnect and verify:
+
+```bash
+cd ~/rugged_rover_ws
+source /opt/ros/jazzy/setup.bash
+source install/setup.bash
+
+ls -l /dev/teensy_uart /dev/rplidar /dev/razor_imu 2>/dev/null
+ros2 pkg list | grep rugged_rover
+```
+
+If a device symlink is missing, check the raw USB devices:
+
+```bash
+lsusb
+ls -l /dev/ttyAMA* /dev/ttyACM* /dev/ttyUSB* 2>/dev/null
+```
+
+## Manual Workspace Setup
+
+If you do not use the Pi installer:
 
 ```bash
 mkdir -p ~/rugged_rover_ws/src
 cd ~/rugged_rover_ws/src
-git clone --branch support-unity-sim --recurse-submodules git@github.com:reeceholland/rugged_rover.git
-git clone --branch main-ros2 https://github.com/Unity-Technologies/ROS-TCP-Endpoint.git
+git clone --branch support-unity-sim git@github.com:reeceholland/rugged_rover.git
 cd rugged_rover
 git submodule update --init --recursive
 
 cd ~/rugged_rover_ws
 source /opt/ros/jazzy/setup.bash
-rosdep install --from-paths src --ignore-src --rosdistro jazzy -r -y
+rosdep install --from-paths src --ignore-src -r -y --rosdistro jazzy
 colcon build --symlink-install
 source install/setup.bash
 ```
 
-If only changing this repo, a focused build is usually enough:
+Useful focused rebuild:
 
 ```bash
 cd ~/rugged_rover_ws
@@ -94,26 +135,118 @@ colcon build --symlink-install --packages-up-to rugged_rover_bringup
 source install/setup.bash
 ```
 
-## Hardware Bringup
+## Teensy Firmware
 
-The hardware path expects a Teensy 4.1 running the firmware in `micro_ros_platform_firmware/platform` and a micro-ROS Agent connected over USB serial.
+Firmware lives in:
 
-Attach the Teensy to WSL if working from Windows:
-
-```powershell
-usbipd list
-usbipd bind --busid <BUSID>
-usbipd attach --wsl --busid <BUSID>
+```text
+micro_ros_platform_firmware/platform
 ```
 
-Then in WSL:
+For normal rover operation, `config.hpp` should contain:
+
+```cpp
+#define USE_ROS 1
+```
+
+For Arduino Serial Monitor bench testing without ROS:
+
+```cpp
+#define USE_ROS 0
+```
+
+In bench mode the firmware accepts:
+
+```text
+<left_rad_s> <right_rad_s>
+```
+
+Example:
+
+```text
+2.0 2.0
+```
+
+Use the Arduino IDE with Teensyduino to flash:
+
+1. Open `micro_ros_platform_firmware/platform/platform.ino`.
+2. Select the Teensy 4.1 board.
+3. Confirm `USE_ROS` is set correctly.
+4. Build and upload.
+5. Power-cycle the Sabertooth if the motor driver does not respond after firmware changes.
+
+The firmware publishes:
+
+- `/platform/motors/feedback`
+- `/battery/voltage`
+- `/platform/debug`
+
+and subscribes to:
+
+- `/platform/motors/cmd`
+
+## Wiring Summary
+
+Teensy to Raspberry Pi UART:
+
+```text
+Pi GPIO14 / TXD0 / pin 8  -> Teensy RX1 / pin 0
+Pi GPIO15 / RXD0 / pin 10 -> Teensy TX1 / pin 1
+Pi GND                   -> Teensy GND
+```
+
+Teensy to Sabertooth:
+
+```text
+Teensy TX2 / pin 8 -> level shifter -> Sabertooth S1
+Teensy GND         -> Sabertooth 0V / battery ground
+```
+
+Battery voltage monitor:
+
+```text
+Battery + -> 100k resistor -> Teensy A9 -> 33k resistor -> GND
+Teensy A9 -> 100 nF capacitor -> GND
+Battery - -> common ground
+```
+
+Important electrical notes:
+
+- The Pi, Teensy, Sabertooth signal ground, battery monitor ground, and sensor grounds must share a common reference.
+- Do not power high-current USB devices from an overloaded Pi USB bus.
+- The D435 should run from a stable USB3 path. If the kernel reports `over-current change`, move the D435 or RPLIDAR power to a powered hub or separate 5 V supply.
+
+## Device Checks
+
+Check the Pi is not throttling:
 
 ```bash
-ls /dev/ttyACM*
-sudo chmod a+rw /dev/ttyACM0
+vcgencmd get_throttled
 ```
 
-Launch the rover hardware stack:
+Expected:
+
+```text
+throttled=0x0
+```
+
+Check USB topology:
+
+```bash
+lsusb -t
+```
+
+The D435 should appear on a `5000M` USB3 bus. If it appears on `480M`, change the cable or USB port.
+
+Watch kernel USB events:
+
+```bash
+sudo dmesg -w
+```
+
+## Bring Up the A4WD3
+
+Launch the real rover baseline:
 
 ```bash
 cd ~/rugged_rover_ws
@@ -122,111 +255,231 @@ source install/setup.bash
 ros2 launch rugged_rover_bringup bringup.launch.py
 ```
 
-Useful manual motor test:
+By default this launches:
+
+- micro-ROS Agent on `/dev/ttyAMA0`
+- battery voltage monitor
+- robot state publisher
+- Razor IMU driver
+- RPLIDAR S2 driver
+- SLAM Toolbox
+- `ros2_control`
+- `joint_state_broadcaster`
+- `diff_drive_controller`
+
+EKF is off by default while validating raw wheel odometry. Enable it with:
 
 ```bash
-ros2 topic pub --once /platform/motors/cmd sensor_msgs/msg/JointState "
-name:
-- front_left_joint
-- front_right_joint
-- rear_left_joint
-- rear_right_joint
-velocity:
-- 2.0
-- 2.0
-- 2.0
-- 2.0
-"
+ros2 launch rugged_rover_bringup bringup.launch.py use_ekf:=true
 ```
 
-Stop command:
+Disable SLAM if you only want low-level control testing:
 
 ```bash
-ros2 topic pub --once /platform/motors/cmd sensor_msgs/msg/JointState "
-name:
-- front_left_joint
-- front_right_joint
-- rear_left_joint
-- rear_right_joint
-velocity:
-- 0.0
-- 0.0
-- 0.0
-- 0.0
-"
+ros2 launch rugged_rover_bringup bringup.launch.py use_slam:=false
 ```
 
-## Unity Simulation
-
-The Unity simulation publishes sensor data and motor feedback through `ros_tcp_endpoint`. The `ros_tcp_endpoint` package comes from the sibling `ROS-TCP-Endpoint` checkout in the workspace. Start the ROS side first:
+Disable the RPLIDAR:
 
 ```bash
-cd ~/rugged_rover_ws
-source /opt/ros/jazzy/setup.bash
-source install/setup.bash
-ros2 launch rugged_rover_bringup unity_sim.launch.py
+ros2 launch rugged_rover_bringup bringup.launch.py use_rplidar:=false
 ```
 
-Then press Play in Unity. The ROS TCP endpoint is configured for:
+Use an explicit RPLIDAR port:
+
+```bash
+ros2 launch rugged_rover_bringup bringup.launch.py rplidar_serial_port:=/dev/ttyUSB0
+```
+
+## Validate the Stack
+
+Check nodes:
+
+```bash
+ros2 node list
+```
+
+Check controllers:
+
+```bash
+ros2 control list_controllers
+```
+
+Expected:
 
 ```text
-ROS_IP=127.0.0.1
-ROS_TCP_PORT=10000
+joint_state_broadcaster active
+diff_drive_controller active
 ```
 
-The simulation launch remaps Unity odometry and TF away from the navigation-owned topics so wheel odometry, robot state publisher, SLAM, and Nav2 can own the normal ROS navigation frames.
-
-## Viewing the Robot
-
-View the robot model by itself:
+Check main topics:
 
 ```bash
-ros2 launch rugged_rover_robot_description view_robot.launch.py
+ros2 topic list
+ros2 topic hz /platform/motors/feedback
+ros2 topic hz /joint_states
+ros2 topic hz /diff_drive_controller/odom
+ros2 topic hz /scan
+ros2 topic echo /battery/voltage --once
+ros2 topic echo /platform/debug --once
 ```
 
-Open the simulation RViz config:
+Check TF:
 
 ```bash
-ros2 launch rugged_rover_robot_description sim_rviz.launch.py
+ros2 run tf2_ros tf2_echo odom base_link
+ros2 run tf2_ros tf2_echo base_link laser
+ros2 run tf2_tools view_frames
 ```
 
-For Unity simulation, RViz should normally use `use_sim_time:=true` and a fixed frame appropriate to the current stack, usually `odom` before SLAM and `map` after SLAM is active.
-
-## SLAM
-
-Start SLAM Toolbox:
-
-```bash
-ros2 launch rugged_rover_bringup slam.launch.py
-```
-
-This launch starts `async_slam_toolbox_node` and transitions it through configure and activate automatically. It expects:
-
-- `/clock` when `use_sim_time:=true`
-- `/scan` from Unity or a real lidar
-- a valid TF chain from `odom` to `base_link` and from `base_link` to the laser frame
-
-Check that a map is being published:
+Check SLAM:
 
 ```bash
 ros2 topic echo /map --once
 ```
 
+## Manual Driving
+
+The diff drive controller currently accepts `TwistStamped`:
+
+```bash
+ros2 topic info /diff_drive_controller/cmd_vel -v
+```
+
+Slow forward command:
+
+```bash
+ros2 topic pub -r 10 /diff_drive_controller/cmd_vel geometry_msgs/msg/TwistStamped "
+header:
+  frame_id: base_link
+twist:
+  linear:
+    x: 0.1
+  angular:
+    z: 0.0
+"
+```
+
+Turn on the spot:
+
+```bash
+ros2 topic pub -r 10 /diff_drive_controller/cmd_vel geometry_msgs/msg/TwistStamped "
+header:
+  frame_id: base_link
+twist:
+  linear:
+    x: 0.0
+  angular:
+    z: 0.4
+"
+```
+
+Stop:
+
+```bash
+ros2 topic pub --once /diff_drive_controller/cmd_vel geometry_msgs/msg/TwistStamped "
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: base_link
+twist:
+  linear:
+    x: 0.0
+  angular:
+    z: 0.0
+"
+```
+
+Direct Teensy motor test:
+
+```bash
+ros2 topic pub --once /platform/motors/cmd sensor_msgs/msg/JointState "
+name:
+- front_left_joint
+- front_right_joint
+- rear_left_joint
+- rear_right_joint
+velocity:
+- 2.0
+- 2.0
+- 2.0
+- 2.0
+"
+```
+
+Direct stop:
+
+```bash
+ros2 topic pub --once /platform/motors/cmd sensor_msgs/msg/JointState "
+name:
+- front_left_joint
+- front_right_joint
+- rear_left_joint
+- rear_right_joint
+velocity:
+- 0.0
+- 0.0
+- 0.0
+- 0.0
+"
+```
+
+If `/diff_drive_controller/cmd_vel` receives commands but the rover does not move, check:
+
+```bash
+ros2 topic echo /platform/motors/cmd
+ros2 topic echo /platform/debug
+ros2 topic echo /battery/voltage
+```
+
+Look for stale commands, `battery_critical=true`, missing micro-ROS connection, or setpoints that reach the Teensy while measured velocity remains zero.
+
+## SLAM
+
+`bringup.launch.py` starts SLAM by default. To launch SLAM separately:
+
+```bash
+ros2 launch rugged_rover_bringup slam.launch.py
+```
+
+SLAM expects:
+
+- `/scan` from the RPLIDAR
+- `odom -> base_link`
+- `base_link -> laser`
+- `use_sim_time:=false` on the real rover
+
+Useful checks:
+
+```bash
+ros2 topic hz /scan
+ros2 run tf2_ros tf2_monitor odom base_link
+ros2 run tf2_ros tf2_monitor map odom
+ros2 topic echo /map --once
+```
+
+Loop closure can be disabled in `rugged_rover_bringup/config/slam_toolbox.yaml`
+while tuning odometry and scan matching.
+
 ## Nav2
 
-Start Nav2:
+Launch Nav2 after bringup is healthy:
 
 ```bash
 ros2 launch rugged_rover_bringup nav2.launch.py
 ```
 
-The Nav2 launch includes a `topic_tools transform` bridge from Nav2's `/cmd_vel` output to the Jazzy diff drive controller's stamped command topic:
+Before sending goals, confirm:
 
-```text
-/cmd_vel -> /diff_drive_controller/cmd_vel
+```bash
+ros2 topic hz /scan
+ros2 topic hz /odom
+ros2 topic echo /map --once
+ros2 run tf2_ros tf2_echo map base_link
 ```
 
-If Nav2 plans but the rover does not move, check:
+If Nav2 plans but does not move the rover:
 
 ```bash
 ros2 topic info /diff_drive_controller/cmd_vel -v
@@ -235,67 +488,197 @@ ros2 topic echo /platform/motors/cmd --once
 ros2 control list_controllers
 ```
 
+If the controller reports old TF data, reduce CPU load, check scan rate, and verify
+that all real-rover nodes have `use_sim_time:=false`.
+
 ## Joystick Teleop
 
-Start joystick teleop after the main hardware or Unity sim stack is running:
+Launch joystick teleop:
 
 ```bash
 ros2 launch rugged_rover_bringup joy.launch.py
 ```
 
-By default this launches `joy_node` and `teleop_twist_joy`, then remaps the output directly to:
-
-```text
-/diff_drive_controller/cmd_vel
-```
-
-The default config uses an Xbox-style layout:
+Default Xbox-style controls:
 
 - Hold `LB` to enable driving
 - Hold `RB` as well for turbo speed
-- Left stick vertical controls forward and reverse
+- Left stick vertical controls forward/reverse
 - Right stick horizontal controls rotation
 
-Use a different joystick device id if needed:
+Use a different joystick device id:
 
 ```bash
 ros2 launch rugged_rover_bringup joy.launch.py joy_dev:=1
 ```
 
-Debug the controller and teleop mapping with:
+Debug joystick messages and generated velocity commands:
 
 ```bash
 ros2 launch rugged_rover_bringup joy_debug.launch.py
 ```
 
-That launch prints both raw `/joy` messages and the generated `/diff_drive_controller/cmd_vel` commands.
+## RPLIDAR S2
 
-## Teensy Firmware Notes
+Launch only the RPLIDAR:
 
-The firmware lives in:
+```bash
+ros2 launch rugged_rover_bringup rplidar_s2.launch.py
+```
+
+Check scan output:
+
+```bash
+ros2 topic echo /scan --once
+ros2 topic hz /scan
+```
+
+If the lidar stops when the D435 starts, inspect USB power events:
+
+```bash
+sudo dmesg -w
+```
+
+`over-current change` or `USB disconnect` means the Pi USB bus is being overloaded.
+Use a powered USB3 hub or separate sensor power.
+
+## RealSense D435
+
+Launch the D435:
+
+```bash
+ros2 launch rugged_rover_bringup d435.launch.py
+```
+
+This publishes depth camera data and remaps `depthimage_to_laserscan` to:
 
 ```text
-micro_ros_platform_firmware/platform
+/depth_scan
 ```
 
-Important modes are controlled from `config.hpp`:
-
-```cpp
-#define USE_ROS 1
-```
-
-Use `USE_ROS 1` for micro-ROS operation. Use `USE_ROS 0` for direct Arduino Serial Monitor testing, where the firmware accepts left/right wheel speed commands in radians per second.
-
-The current hardware wiring expects the Sabertooth serial command line on Teensy `Serial2`:
+The RPLIDAR should remain the owner of:
 
 ```text
-Teensy 4.1 pin 8  TX2 -> level shifter -> Sabertooth S1
-Teensy GND             -> Sabertooth 0V / battery ground
+/scan
 ```
 
-## Formatting and Checks
+Check ownership:
 
-Format C++ code with:
+```bash
+ros2 topic info /scan -v
+ros2 topic info /depth_scan -v
+```
+
+The D435 should enumerate as USB3:
+
+```bash
+lsusb -t
+```
+
+Look for `5000M`. If it disconnects while streaming, use a better USB3 cable,
+another USB3 port, or a powered USB3 hub.
+
+## Unity Simulation
+
+Unity simulation support lives in `rugged_rover_bringup/launch/unity_sim.launch.py`.
+Start the ROS side:
+
+```bash
+cd ~/rugged_rover_ws
+source /opt/ros/jazzy/setup.bash
+source install/setup.bash
+ros2 launch rugged_rover_bringup unity_sim.launch.py
+```
+
+Then press Play in Unity.
+
+The Unity simulation normally uses:
+
+```text
+ROS_IP=127.0.0.1
+ROS_TCP_PORT=10000
+```
+
+When testing fault injection, some Unity topics may be remapped with a `_raw`
+postfix. Make sure SLAM subscribes to the topic that Unity is actually publishing:
+
+```bash
+ros2 topic info /scan -v
+ros2 topic info /scan_raw -v
+```
+
+## Common Troubleshooting
+
+No `/platform/motors/cmd` subscriber:
+
+```bash
+ros2 node list | grep micro
+ros2 topic info /platform/motors/cmd -v
+```
+
+If the Teensy is not connected, check the agent:
+
+```bash
+ros2 run micro_ros_agent micro_ros_agent serial --dev /dev/ttyAMA0 -b 115200
+```
+
+Permission denied on `/dev/ttyAMA0`:
+
+```bash
+groups
+ls -l /dev/ttyAMA0
+sudo chmod 666 /dev/ttyAMA0
+```
+
+The `chmod` command is a temporary fix. The persistent fix is the udev rule in
+`install_pi5_ubuntu24_ros_jazzy.sh`, followed by a reboot.
+
+Lidar or camera disappears:
+
+```bash
+sudo dmesg -w
+lsusb
+lsusb -t
+```
+
+Rover moves in RViz but not physically:
+
+```bash
+ros2 topic echo /platform/motors/cmd
+ros2 topic echo /platform/debug
+```
+
+Physical rover moves but odom is wrong:
+
+- verify encoder counts and gearbox ratio in the Teensy firmware
+- verify wheel radius in `rugged_rover_control/config/controllers.yaml`
+- verify effective wheel separation with a 360 degree rotation test
+
+SLAM map jumps or duplicates rooms:
+
+- validate `/diff_drive_controller/odom` first
+- check `odom -> base_link` TF age
+- disable loop closure while tuning
+- confirm the laser frame transform is correct
+- keep CPU load low enough that scan processing does not fall behind
+
+Stop common ROS processes:
+
+```bash
+pkill -f ros_tcp_endpoint
+pkill -f slam_toolbox
+pkill -f rviz2
+pkill -f ros2_control_node
+pkill -f robot_state_publisher
+pkill -f ekf_node
+pkill -f micro_ros_agent
+ros2 daemon stop
+ros2 daemon start
+```
+
+## Formatting and Tests
+
+Format C++ files:
 
 ```bash
 find . \( -name "*.cpp" -o -name "*.hpp" \) -exec clang-format -i {} +
@@ -309,20 +692,12 @@ source /opt/ros/jazzy/setup.bash
 colcon build --symlink-install --packages-up-to rugged_rover_bringup
 ```
 
-Run the hardware interface test package when needed:
+Run hardware interface tests:
 
 ```bash
 colcon test --packages-select rugged_rover_hardware_interfaces
 colcon test-result --verbose
 ```
-
-## Current Development Focus
-
-- Robust real rover motor control through Teensy + Sabertooth + encoder feedback
-- Unity simulation parity with the physical rover
-- SLAM and Nav2 tuning for the rover footprint and available sensors
-- Raspberry Pi deployment on Ubuntu 24.04 + ROS 2 Jazzy
-- Future real-world perception with camera/depth/lidar inputs
 
 ## Maintainer
 

--- a/micro_ros_platform_firmware/platform/config.hpp
+++ b/micro_ros_platform_firmware/platform/config.hpp
@@ -5,6 +5,7 @@
 #define USE_ROS 1
 
 extern bool SERIAL_DEBUG;
+constexpr bool ROS_SERIAL_STATUS_DEBUG = false;
 
 #define BATTERY_VOLTAGE_PIN A9
 

--- a/micro_ros_platform_firmware/platform/config.hpp
+++ b/micro_ros_platform_firmware/platform/config.hpp
@@ -13,4 +13,5 @@ constexpr float BATTERY_R_TOP = 100000.0f;
 constexpr float BATTERY_R_BOTTOM = 33000.0f;
 constexpr float ADC_REFERENCE_VOLTAGE = 3.3f;
 constexpr float BATTERY_PUBLISH_PERIOD_MS = 1000.0f;
+constexpr unsigned long DEBUG_PUBLISH_PERIOD_MS = 1000;
 constexpr unsigned long MOTOR_COMMAND_TIMEOUT_MS = 500;

--- a/micro_ros_platform_firmware/platform/motor_control.hpp
+++ b/micro_ros_platform_firmware/platform/motor_control.hpp
@@ -10,7 +10,7 @@
 // The encoder library counts quadrature edges. A 12 PPR encoder normally
 // produces 48 counts per motor revolution when both channels are decoded.
 constexpr float ENCODER_COUNTS_PER_MOTOR_REV = 48.0;
-constexpr float GEAR_RATIO_MULTIPLIER = 27.0;
+constexpr float GEAR_RATIO_MULTIPLIER = 51.0;
 
 // Control variables
 extern float front_left_velocity_setpoint;

--- a/micro_ros_platform_firmware/platform/msg_utils.cpp
+++ b/micro_ros_platform_firmware/platform/msg_utils.cpp
@@ -20,6 +20,7 @@ double cmd_position_data[MAX_JOINTS];
 double cmd_velocity_data[MAX_JOINTS];
 double feedback_position_data[MAX_JOINTS];
 double feedback_velocity_data[MAX_JOINTS];
+char debug_message_buffer[DEBUG_MESSAGE_LEN];
 
 namespace
 {
@@ -83,6 +84,14 @@ void initialise_battery_voltage_message(std_msgs__msg__Float32& msg)
   msg.data = 0.0f;
 }
 
+void initialise_debug_message(std_msgs__msg__String& msg)
+{
+  debug_message_buffer[0] = '\0';
+  msg.data.data = debug_message_buffer;
+  msg.data.size = 0;
+  msg.data.capacity = DEBUG_MESSAGE_LEN;
+}
+
 void publish_battery_voltage_message()
 {
   static unsigned long last_publish_ms = 0;
@@ -97,6 +106,43 @@ void publish_battery_voltage_message()
 
   battery_voltage_msg.data = read_battery_voltage();
   RCSOFTCHECK(rcl_publish(&battery_voltage_publisher, &battery_voltage_msg, NULL));
+}
+
+void publish_debug_message()
+{
+  static unsigned long last_publish_ms = 0;
+  const unsigned long now = millis();
+
+  if (now - last_publish_ms < DEBUG_PUBLISH_PERIOD_MS)
+  {
+    return;
+  }
+
+  last_publish_ms = now;
+
+  const long last_cmd_age_ms =
+      last_motor_command_ms == 0 ? -1 : static_cast<long>(now - last_motor_command_ms);
+
+  const int written = snprintf(
+      debug_message_buffer, DEBUG_MESSAGE_LEN,
+      "ros=%s battery_critical=%s battery_v=%.2f last_cmd_age_ms=%ld "
+      "setpoints_fl=%.3f setpoints_fr=%.3f measured_fl=%.3f measured_fr=%.3f "
+      "output_fl=%.2f output_fr=%.2f",
+      ros_is_connected() ? "connected" : "waiting", battery_is_critical() ? "true" : "false",
+      read_battery_voltage(), last_cmd_age_ms, front_left_velocity_setpoint,
+      front_right_velocity_setpoint, current_front_left_rads_sec, current_front_right_rads_sec,
+      front_left_output, front_right_output);
+
+  if (written < 0)
+  {
+    return;
+  }
+
+  debug_message_buffer[DEBUG_MESSAGE_LEN - 1] = '\0';
+  debug_msg.data.size =
+      written >= DEBUG_MESSAGE_LEN ? DEBUG_MESSAGE_LEN - 1 : static_cast<size_t>(written);
+
+  RCSOFTCHECK(rcl_publish(&debug_publisher, &debug_msg, NULL));
 }
 
 /**
@@ -187,4 +233,5 @@ void subscription_callback(const void* msgin)
 #else
 void publish_joint_state_message() {}
 void publish_battery_voltage_message() {}
+void publish_debug_message() {}
 #endif

--- a/micro_ros_platform_firmware/platform/msg_utils.cpp
+++ b/micro_ros_platform_firmware/platform/msg_utils.cpp
@@ -47,7 +47,7 @@ void initialise_joint_state_message(sensor_msgs__msg__JointState& msg)
   const bool is_feedback_msg = (&msg == &feedback_msg);
 
   rosidl_runtime_c__String* names = is_feedback_msg ? feedback_name_data : cmd_name_data;
-  char (*name_storage)[MAX_NAME_LEN] = is_feedback_msg ? feedback_name_buffer : cmd_name_buffer;
+  char(*name_storage)[MAX_NAME_LEN] = is_feedback_msg ? feedback_name_buffer : cmd_name_buffer;
   double* positions = is_feedback_msg ? feedback_position_data : cmd_position_data;
   double* velocities = is_feedback_msg ? feedback_velocity_data : cmd_velocity_data;
 

--- a/micro_ros_platform_firmware/platform/msg_utils.hpp
+++ b/micro_ros_platform_firmware/platform/msg_utils.hpp
@@ -6,17 +6,21 @@
 #include <micro_ros_arduino.h>
 #include <sensor_msgs/msg/joint_state.h>
 #include <std_msgs/msg/float32.h>
+#include <std_msgs/msg/string.h>
 #endif
 
 #define MAX_JOINTS 4
 #define MAX_NAME_LEN 25
+#define DEBUG_MESSAGE_LEN 192
 
 #if USE_ROS
 void initialise_joint_state_message(sensor_msgs__msg__JointState& msg);
 void initialise_battery_voltage_message(std_msgs__msg__Float32& msg);
+void initialise_debug_message(std_msgs__msg__String& msg);
 #endif
 void publish_joint_state_message();
 void publish_battery_voltage_message();
+void publish_debug_message();
 #if USE_ROS
 void subscription_callback(const void* msgin);
 #endif

--- a/micro_ros_platform_firmware/platform/platform.ino
+++ b/micro_ros_platform_firmware/platform/platform.ino
@@ -135,6 +135,7 @@ void loop()
     {
       publish_joint_state_message();
       publish_battery_voltage_message();
+      publish_debug_message();
     }
     update_motors();
   }

--- a/micro_ros_platform_firmware/platform/platform.ino
+++ b/micro_ros_platform_firmware/platform/platform.ino
@@ -139,7 +139,7 @@ void loop()
     update_motors();
   }
 
-  if (USE_ROS)
+  if (USE_ROS && ROS_SERIAL_STATUS_DEBUG)
   {
     static unsigned long last_debug_ms = 0;
     if (now - last_debug_ms >= 1000)

--- a/micro_ros_platform_firmware/platform/ros_interface.cpp
+++ b/micro_ros_platform_firmware/platform/ros_interface.cpp
@@ -93,7 +93,7 @@ namespace
     }
     node_created = true;
 
-    rcutils_logging_set_default_logger_level(RCUTILS_LOG_SEVERITY_DEBUG);
+    rcutils_logging_set_default_logger_level(RCUTILS_LOG_SEVERITY_WARN);
 
     sensor_msgs__msg__JointState__init(&cmd_msg);
     sensor_msgs__msg__JointState__init(&feedback_msg);

--- a/micro_ros_platform_firmware/platform/ros_interface.cpp
+++ b/micro_ros_platform_firmware/platform/ros_interface.cpp
@@ -10,6 +10,7 @@
 #include <rmw_microros/ping.h>
 #include <sensor_msgs/msg/joint_state.h>
 #include <std_msgs/msg/float32.h>
+#include <std_msgs/msg/string.h>
 
 rcl_subscription_t joint_state_subscriber;
 rcl_publisher_t feedback_publisher;
@@ -18,10 +19,12 @@ rcl_allocator_t allocator;
 rclc_support_t support;
 rcl_node_t node;
 rcl_publisher_t battery_voltage_publisher;
+rcl_publisher_t debug_publisher;
 
 sensor_msgs__msg__JointState cmd_msg;
 sensor_msgs__msg__JointState feedback_msg;
 std_msgs__msg__Float32 battery_voltage_msg;
+std_msgs__msg__String debug_msg;
 
 extern "C" bool arduino_transport_open(struct uxrCustomTransport*)
 {
@@ -63,6 +66,7 @@ namespace
   bool support_created = false;
   bool node_created = false;
   bool battery_publisher_created = false;
+  bool debug_publisher_created = false;
   bool motor_subscription_created = false;
   bool feedback_publisher_created = false;
   bool executor_created = false;
@@ -100,11 +104,14 @@ namespace
     initialise_joint_state_message(cmd_msg);
     initialise_joint_state_message(feedback_msg);
     initialise_battery_voltage_message(battery_voltage_msg);
+    initialise_debug_message(debug_msg);
 
     const rosidl_message_type_support_t* type_support =
         ROSIDL_GET_MSG_TYPE_SUPPORT(sensor_msgs, msg, JointState);
     const rosidl_message_type_support_t* battery_type_support =
         ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Float32);
+    const rosidl_message_type_support_t* debug_type_support =
+        ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, String);
 
     rcl_subscription_options_t sub_ops = rcl_subscription_get_default_options();
     sub_ops.qos = rmw_qos_profile_sensor_data;
@@ -119,6 +126,14 @@ namespace
       return false;
     }
     battery_publisher_created = true;
+
+    if (rcl_publisher_init(&debug_publisher, &node, debug_type_support, "platform/debug",
+                           &pub_ops) != RCL_RET_OK)
+    {
+      destroy_ros_entities();
+      return false;
+    }
+    debug_publisher_created = true;
 
     if (rcl_subscription_init(&joint_state_subscriber, &node, type_support,
                               "platform/motors/cmd", &sub_ops) != RCL_RET_OK)
@@ -166,6 +181,12 @@ namespace
     {
       rcl_publisher_fini(&feedback_publisher, &node);
       feedback_publisher_created = false;
+    }
+
+    if (debug_publisher_created)
+    {
+      rcl_publisher_fini(&debug_publisher, &node);
+      debug_publisher_created = false;
     }
 
     if (battery_publisher_created)

--- a/micro_ros_platform_firmware/platform/ros_interface.cpp
+++ b/micro_ros_platform_firmware/platform/ros_interface.cpp
@@ -135,16 +135,16 @@ namespace
     }
     debug_publisher_created = true;
 
-    if (rcl_subscription_init(&joint_state_subscriber, &node, type_support,
-                              "platform/motors/cmd", &sub_ops) != RCL_RET_OK)
+    if (rcl_subscription_init(&joint_state_subscriber, &node, type_support, "platform/motors/cmd",
+                              &sub_ops) != RCL_RET_OK)
     {
       destroy_ros_entities();
       return false;
     }
     motor_subscription_created = true;
 
-    if (rcl_publisher_init(&feedback_publisher, &node, type_support,
-                           "platform/motors/feedback", &pub_ops) != RCL_RET_OK)
+    if (rcl_publisher_init(&feedback_publisher, &node, type_support, "platform/motors/feedback",
+                           &pub_ops) != RCL_RET_OK)
     {
       destroy_ros_entities();
       return false;
@@ -305,5 +305,8 @@ void spin_ros_executor()
 void ros_setup() {}
 void ros_update() {}
 void spin_ros_executor() {}
-bool ros_is_connected() { return false; }
+bool ros_is_connected()
+{
+  return false;
+}
 #endif

--- a/micro_ros_platform_firmware/platform/ros_interface.hpp
+++ b/micro_ros_platform_firmware/platform/ros_interface.hpp
@@ -9,6 +9,7 @@
 #include <rclc/rclc.h>
 #include <sensor_msgs/msg/joint_state.h>
 #include <std_msgs/msg/float32.h>
+#include <std_msgs/msg/string.h>
 #endif
 
 void ros_setup();
@@ -23,7 +24,9 @@ extern rclc_executor_t executor;
 extern rcl_subscription_t joint_state_subscriber;
 extern rcl_publisher_t feedback_publisher;
 extern rcl_publisher_t battery_voltage_publisher;
+extern rcl_publisher_t debug_publisher;
 extern sensor_msgs__msg__JointState cmd_msg;
 extern sensor_msgs__msg__JointState feedback_msg;
 extern std_msgs__msg__Float32 battery_voltage_msg;
+extern std_msgs__msg__String debug_msg;
 #endif

--- a/rugged_rover_battery/src/battery_voltage_monitor.cpp
+++ b/rugged_rover_battery/src/battery_voltage_monitor.cpp
@@ -23,8 +23,8 @@ namespace rugged_rover_battery
 
     auto timer_period = std::chrono::milliseconds(500);
 
-    stale_timer_ = this->create_wall_timer(
-        timer_period, std::bind(&BatteryVoltageMonitor::timerCallback, this));
+    stale_timer_ = this->create_wall_timer(timer_period,
+                                           std::bind(&BatteryVoltageMonitor::timerCallback, this));
 
     // Initialize subscriber. Teensy firmware and Unity publish the raw voltage here.
     battery_voltage_sub_ = this->create_subscription<std_msgs::msg::Float32>(

--- a/rugged_rover_bootstrap/install_pi5_ubuntu24_ros_jazzy.sh
+++ b/rugged_rover_bootstrap/install_pi5_ubuntu24_ros_jazzy.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Bootstrap a Raspberry Pi 5 for Rugged Rover.
+# Target: Ubuntu Server 24.04 + ROS 2 Jazzy.
+#
+# This script is designed to run from inside the rugged_rover repository:
+#   cd ~/rugged_rover_ws/src/rugged_rover
+#   bash rugged_rover_bootstrap/install_pi5_ubuntu24_ros_jazzy.sh
+#
+# It also repairs a common fresh-image apt issue where noble-updates is missing,
+# which can leave packages such as bzip2/libbz2 with incompatible versions.
+
+ROS_DISTRO="${ROS_DISTRO:-jazzy}"
+WORKSPACE_DIR="${WORKSPACE_DIR:-$HOME/rugged_rover_ws}"
+REPO_DIR="${REPO_DIR:-$WORKSPACE_DIR/src/rugged_rover}"
+REPO_URL="${REPO_URL:-git@github.com:reeceholland/rugged_rover.git}"
+REPO_BRANCH="${REPO_BRANCH:-support-unity-sim}"
+GIT_USER_NAME="${GIT_USER_NAME:-Reece Holland}"
+GIT_USER_EMAIL="${GIT_USER_EMAIL:-reece.j.holland@gmail.com}"
+
+log() {
+  echo
+  echo "==> $*"
+}
+
+require_ubuntu_24_04() {
+  if [[ ! -r /etc/os-release ]]; then
+    echo "Cannot read /etc/os-release; refusing to continue." >&2
+    exit 1
+  fi
+
+  # shellcheck disable=SC1091
+  source /etc/os-release
+  if [[ "${ID:-}" != "ubuntu" || "${VERSION_ID:-}" != "24.04" ]]; then
+    echo "This script targets Ubuntu 24.04. Detected: ${PRETTY_NAME:-unknown}" >&2
+    exit 1
+  fi
+}
+
+ensure_ubuntu_updates_repo() {
+  log "Checking Ubuntu apt suites"
+
+  local sources_file="/etc/apt/sources.list.d/ubuntu.sources"
+
+  if grep -Rqs "Suites:.*noble-updates" /etc/apt/sources.list /etc/apt/sources.list.d 2>/dev/null; then
+    echo "noble-updates already configured."
+  elif [[ -f "$sources_file" ]]; then
+    sudo cp "$sources_file" "${sources_file}.bak.$(date +%Y%m%d%H%M%S)"
+    sudo python3 - <<'PY'
+from pathlib import Path
+path = Path('/etc/apt/sources.list.d/ubuntu.sources')
+text = path.read_text()
+text = text.replace('Suites: noble\n', 'Suites: noble noble-updates\n', 1)
+path.write_text(text)
+PY
+  else
+    sudo tee /etc/apt/sources.list.d/99-ubuntu-noble-updates.sources >/dev/null <<'APT'
+Types: deb
+URIs: http://ports.ubuntu.com/ubuntu-ports/
+Suites: noble-updates
+Components: main restricted universe multiverse
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+APT
+  fi
+
+  sudo apt update
+}
+
+repair_base_apt_state() {
+  log "Repairing base apt state"
+
+  sudo dpkg --configure -a
+  sudo apt --fix-broken install -y
+
+  # The Pi image previously had libbz2 from noble-updates while noble-updates was
+  # missing from apt sources. Install bzip2 explicitly after repairing sources so
+  # dpkg-dev and build-essential can resolve cleanly.
+  sudo apt install -y bzip2 libbz2-1.0
+}
+
+configure_git() {
+  log "Configuring git identity"
+  git config --global user.name "$GIT_USER_NAME"
+  git config --global user.email "$GIT_USER_EMAIL"
+}
+
+install_base_tools() {
+  log "Installing base utilities"
+  sudo apt install -y \
+    apt-transport-https \
+    bash-completion \
+    build-essential \
+    ca-certificates \
+    chrony \
+    cmake \
+    curl \
+    git \
+    gnupg \
+    htop \
+    iproute2 \
+    iw \
+    libasio-dev \
+    lsb-release \
+    nano \
+    ninja-build \
+    openssh-server \
+    python3-argcomplete \
+    python3-pip \
+    python3-venv \
+    software-properties-common \
+    tmux \
+    udev \
+    usbutils
+
+  sudo systemctl enable --now ssh
+  sudo systemctl enable --now chrony || true
+}
+
+configure_ros_apt_repo() {
+  log "Configuring ROS 2 apt repository"
+  sudo add-apt-repository universe -y
+
+  sudo install -d -m 0755 /etc/apt/keyrings
+  if [[ ! -f /etc/apt/keyrings/ros-archive-keyring.gpg ]]; then
+    curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key |
+      sudo gpg --dearmor -o /etc/apt/keyrings/ros-archive-keyring.gpg
+  fi
+
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo "$UBUNTU_CODENAME") main" |
+    sudo tee /etc/apt/sources.list.d/ros2.list >/dev/null
+
+  sudo apt update
+}
+
+install_ros_packages() {
+  log "Installing ROS 2 ${ROS_DISTRO} packages"
+  sudo apt install -y \
+    python3-colcon-common-extensions \
+    python3-rosdep \
+    python3-vcstool \
+    ros-dev-tools \
+    "ros-${ROS_DISTRO}-controller-manager" \
+    "ros-${ROS_DISTRO}-depthimage-to-laserscan" \
+    "ros-${ROS_DISTRO}-diagnostic-updater" \
+    "ros-${ROS_DISTRO}-diff-drive-controller" \
+    "ros-${ROS_DISTRO}-image-transport" \
+    "ros-${ROS_DISTRO}-joint-state-broadcaster" \
+    "ros-${ROS_DISTRO}-joy" \
+    "ros-${ROS_DISTRO}-nav2-bringup" \
+    "ros-${ROS_DISTRO}-navigation2" \
+    "ros-${ROS_DISTRO}-realsense2-camera" \
+    "ros-${ROS_DISTRO}-robot-localization" \
+    "ros-${ROS_DISTRO}-robot-state-publisher" \
+    "ros-${ROS_DISTRO}-ros-base" \
+    "ros-${ROS_DISTRO}-ros2-control" \
+    "ros-${ROS_DISTRO}-ros2-controllers" \
+    "ros-${ROS_DISTRO}-slam-toolbox" \
+    "ros-${ROS_DISTRO}-teleop-twist-joy" \
+    "ros-${ROS_DISTRO}-tf2-tools" \
+    "ros-${ROS_DISTRO}-topic-tools" \
+    "ros-${ROS_DISTRO}-xacro"
+}
+
+configure_rosdep() {
+  log "Configuring rosdep"
+  if [[ ! -f /etc/ros/rosdep/sources.list.d/20-default.list ]]; then
+    sudo rosdep init
+  fi
+  rosdep update
+}
+
+configure_groups_and_udev() {
+  log "Configuring serial/GPIO permissions and device aliases"
+  sudo usermod -aG dialout,input,gpio,i2c,spi "$USER" || true
+
+  sudo tee /etc/udev/rules.d/99-rugged-rover.rules >/dev/null <<'UDEV'
+# Raspberry Pi primary UART used by the Teensy micro-ROS transport.
+KERNEL=="ttyAMA0", GROUP="dialout", MODE="0660", SYMLINK+="teensy_uart"
+
+# RPLIDAR S2 USB serial adapter. Most units enumerate as Silicon Labs CP210x.
+SUBSYSTEM=="tty", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", GROUP="dialout", MODE="0660", SYMLINK+="rplidar"
+
+# SparkFun 9DoF Razor IMU.
+SUBSYSTEM=="tty", ATTRS{idVendor}=="1b4f", ATTRS{idProduct}=="9d0f", GROUP="dialout", MODE="0660", SYMLINK+="razor_imu"
+UDEV
+
+  sudo udevadm control --reload-rules
+  sudo udevadm trigger || true
+}
+
+ensure_repo_present() {
+  log "Ensuring rugged_rover repository is present"
+  mkdir -p "$WORKSPACE_DIR/src"
+
+  if [[ -d "$REPO_DIR/.git" ]]; then
+    git -C "$REPO_DIR" fetch --all --prune || true
+    git -C "$REPO_DIR" checkout "$REPO_BRANCH" || true
+    git -C "$REPO_DIR" pull --ff-only || true
+  else
+    git clone --branch "$REPO_BRANCH" "$REPO_URL" "$REPO_DIR"
+  fi
+
+  git -C "$REPO_DIR" submodule update --init --recursive
+}
+
+install_workspace_dependencies() {
+  log "Installing workspace dependencies with rosdep"
+  cd "$WORKSPACE_DIR"
+  rosdep install --from-paths src --ignore-src -r -y --rosdistro "$ROS_DISTRO"
+}
+
+build_workspace() {
+  log "Building workspace"
+  cd "$WORKSPACE_DIR"
+  # shellcheck disable=SC1090
+  source "/opt/ros/${ROS_DISTRO}/setup.bash"
+  colcon build --symlink-install
+}
+
+configure_shell() {
+  log "Configuring shell environment"
+  local bashrc="$HOME/.bashrc"
+
+  grep -qxF "source /opt/ros/${ROS_DISTRO}/setup.bash" "$bashrc" ||
+    echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >>"$bashrc"
+
+  grep -qxF "if [ -f \"$WORKSPACE_DIR/install/setup.bash\" ]; then source \"$WORKSPACE_DIR/install/setup.bash\"; fi" "$bashrc" ||
+    echo "if [ -f \"$WORKSPACE_DIR/install/setup.bash\" ]; then source \"$WORKSPACE_DIR/install/setup.bash\"; fi" >>"$bashrc"
+
+  grep -qxF "export ROS_DOMAIN_ID=0" "$bashrc" ||
+    echo "export ROS_DOMAIN_ID=0" >>"$bashrc"
+
+  grep -qxF "export RMW_IMPLEMENTATION=rmw_fastrtps_cpp" "$bashrc" ||
+    echo "export RMW_IMPLEMENTATION=rmw_fastrtps_cpp" >>"$bashrc"
+}
+
+print_next_steps() {
+  cat <<EOF
+
+Setup complete.
+
+Recommended next steps:
+  1. Reboot so group/udev changes are definitely active:
+       sudo reboot
+
+  2. After reconnecting, verify devices:
+       ls -l /dev/teensy_uart /dev/rplidar /dev/razor_imu 2>/dev/null || true
+
+  3. Launch the rover baseline:
+       ros2 launch rugged_rover_bringup bringup.launch.py use_ekf:=true use_slam:=true use_rplidar:=true
+
+Notes:
+  - If bzip2/libbz2 failed before, this script enables noble-updates before installing build tools.
+  - If the RPLIDAR symlink does not appear, check lsusb for its VID:PID.
+  - Keep RViz on your laptop when possible; the Pi should run the rover stack.
+EOF
+}
+
+main() {
+  require_ubuntu_24_04
+  ensure_ubuntu_updates_repo
+  repair_base_apt_state
+  configure_git
+  install_base_tools
+  configure_ros_apt_repo
+  install_ros_packages
+  configure_rosdep
+  configure_groups_and_udev
+  ensure_repo_present
+  install_workspace_dependencies
+  build_workspace
+  configure_shell
+  print_next_steps
+}
+
+main "$@"

--- a/rugged_rover_bringup/config/ekf.yaml
+++ b/rugged_rover_bringup/config/ekf.yaml
@@ -1,10 +1,10 @@
 ekf_filter_node:
   ros__parameters:
-    frequency: 20.0
+    frequency: 30.0
     sensor_timeout: 0.2
     two_d_mode: true
     transform_time_offset: 0.0
-    transform_timeout: 0.1
+    transform_timeout: 0.0
     print_diagnostics: false
     debug: false
     publish_tf: true
@@ -15,15 +15,15 @@ ekf_filter_node:
     base_link_frame: base_link
     world_frame: odom
 
-    odom0: /odom_raw
+    odom0: /diff_drive_controller/odom
     # Fuse raw wheel odom pose and twist first. This should behave almost like
     # diff_drive_controller odom, but keeps EKF in the pipeline for later IMU work.
-    odom0_config: [false,  false,  false,
-                   false, false, false,
+    odom0_config: [true,  true,  false,
+                   false, false, true,
                    true,  false, false,
                    false, false, true,
                    false, false, false]
-    odom0_queue_size: 10
+    odom0_queue_size: 30
     odom0_differential: false
     odom0_relative: false
     odom0_pose_rejection_threshold: 5.0
@@ -35,7 +35,7 @@ ekf_filter_node:
                   false, false, false,
                   false, false, true,
                   false, false, false]
-    imu0_queue_size: 10
+    imu0_queue_size: 30
     imu0_differential: false
     imu0_relative: false
     imu0_pose_rejection_threshold: 1.0

--- a/rugged_rover_bringup/config/ekf.yaml
+++ b/rugged_rover_bringup/config/ekf.yaml
@@ -1,6 +1,6 @@
 ekf_filter_node:
   ros__parameters:
-    frequency: 30.0
+    frequency: 20.0
     sensor_timeout: 0.2
     two_d_mode: true
     transform_time_offset: 0.0

--- a/rugged_rover_bringup/config/nav2_params.yaml
+++ b/rugged_rover_bringup/config/nav2_params.yaml
@@ -1,6 +1,6 @@
 bt_navigator:
   ros__parameters:
-    use_sim_time: true
+    use_sim_time: false
     global_frame: map
     robot_base_frame: base_link
     odom_topic: /odom
@@ -15,8 +15,8 @@ bt_navigator:
 
 controller_server:
   ros__parameters:
-    use_sim_time: true
-    controller_frequency: 20.0
+    use_sim_time: false
+    controller_frequency: 5.0
     min_x_velocity_threshold: 0.001
     min_y_velocity_threshold: 0.5
     min_theta_velocity_threshold: 0.001
@@ -41,45 +41,45 @@ controller_server:
       debug_trajectory_details: false
       min_vel_x: 0.0
       min_vel_y: 0.0
-      max_vel_x: 0.35
+      max_vel_x: 0.20
       max_vel_y: 0.0
-      max_vel_theta: 0.8
+      max_vel_theta: 1.5
       min_speed_xy: 0.0
-      max_speed_xy: 0.35
-      min_speed_theta: 0.0
+      max_speed_xy: 0.20
+      min_speed_theta: 0.25
       acc_lim_x: 0.6
       acc_lim_y: 0.0
-      acc_lim_theta: 1.2
+      acc_lim_theta: 3.0
       decel_lim_x: -0.6
       decel_lim_y: 0.0
-      decel_lim_theta: -1.2
+      decel_lim_theta: -3.0
       vx_samples: 20
       vy_samples: 1
-      vtheta_samples: 20
+      vtheta_samples: 40
       sim_time: 1.7
       linear_granularity: 0.05
       angular_granularity: 0.025
-      transform_tolerance: 0.3
+      transform_tolerance: 1.0
       xy_goal_tolerance: 0.25
       trans_stopped_velocity: 0.05
       short_circuit_trajectory_evaluation: true
       stateful: true
       critics: ["RotateToGoal", "Oscillation", "BaseObstacle", "GoalAlign", "PathAlign", "PathDist", "GoalDist"]
       BaseObstacle.scale: 0.02
-      PathAlign.scale: 32.0
+      PathAlign.scale: 48.0
       PathAlign.forward_point_distance: 0.1
-      GoalAlign.scale: 24.0
+      GoalAlign.scale: 48.0
       GoalAlign.forward_point_distance: 0.1
       PathDist.scale: 32.0
       GoalDist.scale: 24.0
-      RotateToGoal.scale: 32.0
-      RotateToGoal.slowing_factor: 5.0
+      RotateToGoal.scale: 64.0
+      RotateToGoal.slowing_factor: 2.0
       RotateToGoal.lookahead_time: -1.0
 
 local_costmap:
   local_costmap:
     ros__parameters:
-      use_sim_time: true
+      use_sim_time: false
       update_frequency: 5.0
       publish_frequency: 2.0
       global_frame: odom
@@ -89,7 +89,7 @@ local_costmap:
       height: 5
       resolution: 0.05
       robot_radius: 0.22
-      transform_tolerance: 0.3
+      transform_tolerance: 1.0
       plugins: ["obstacle_layer", "inflation_layer"]
       obstacle_layer:
         plugin: "nav2_costmap_2d::ObstacleLayer"
@@ -114,7 +114,7 @@ local_costmap:
 global_costmap:
   global_costmap:
     ros__parameters:
-      use_sim_time: true
+      use_sim_time: false
       update_frequency: 1.0
       publish_frequency: 1.0
       global_frame: map
@@ -122,7 +122,7 @@ global_costmap:
       robot_radius: 0.22
       resolution: 0.05
       track_unknown_space: true
-      transform_tolerance: 0.3
+      transform_tolerance: 1.0
       plugins: ["static_layer", "obstacle_layer", "inflation_layer"]
       static_layer:
         plugin: "nav2_costmap_2d::StaticLayer"
@@ -149,7 +149,7 @@ global_costmap:
 
 planner_server:
   ros__parameters:
-    use_sim_time: true
+    use_sim_time: false
     expected_planner_frequency: 5.0
     planner_plugins: ["GridBased"]
     GridBased:
@@ -160,7 +160,7 @@ planner_server:
 
 smoother_server:
   ros__parameters:
-    use_sim_time: true
+    use_sim_time: false
     smoother_plugins: ["simple_smoother"]
     simple_smoother:
       plugin: "nav2_smoother::SimpleSmoother"
@@ -170,7 +170,7 @@ smoother_server:
 
 behavior_server:
   ros__parameters:
-    use_sim_time: true
+    use_sim_time: false
     local_costmap_topic: local_costmap/costmap_raw
     global_costmap_topic: global_costmap/costmap_raw
     local_footprint_topic: local_costmap/published_footprint
@@ -195,7 +195,7 @@ behavior_server:
 
 waypoint_follower:
   ros__parameters:
-    use_sim_time: true
+    use_sim_time: false
     loop_rate: 20
     stop_on_failure: false
     waypoint_task_executor_plugin: "wait_at_waypoint"
@@ -206,7 +206,7 @@ waypoint_follower:
 
 velocity_smoother:
   ros__parameters:
-    use_sim_time: true
+    use_sim_time: false
     smoothing_frequency: 20.0
     scale_velocities: false
     feedback: "OPEN_LOOP"
@@ -221,7 +221,7 @@ velocity_smoother:
 
 collision_monitor:
   ros__parameters:
-    use_sim_time: true
+    use_sim_time: false
     base_frame_id: "base_link"
     odom_frame_id: "odom"
     cmd_vel_in_topic: "cmd_vel_smoothed"
@@ -253,7 +253,7 @@ collision_monitor:
 
 docking_server:
   ros__parameters:
-    use_sim_time: true
+    use_sim_time: false
     controller_frequency: 50.0
     initial_perception_timeout: 5.0
     wait_charge_timeout: 5.0

--- a/rugged_rover_bringup/config/slam_toolbox.yaml
+++ b/rugged_rover_bringup/config/slam_toolbox.yaml
@@ -75,7 +75,7 @@ slam_toolbox:
     link_scan_maximum_distance: 1.5
 
     # Loop closure can fix drift, but can also cause large pose jumps if false matches occur.
-    do_loop_closing: true
+    do_loop_closing: false
 
     # Maximum distance to search for loop closures.
     loop_search_maximum_distance: 1.5

--- a/rugged_rover_bringup/config/slam_toolbox.yaml
+++ b/rugged_rover_bringup/config/slam_toolbox.yaml
@@ -1,23 +1,48 @@
 slam_toolbox:
   ros__parameters:
-    use_sim_time: true
+    # Use wall time on the real rover. Set true only in Unity/simulation with /clock.
+    use_sim_time: false
 
+    # Live mapping mode. SLAM consumes odom + laser scans and publishes map -> odom.
     mode: mapping
+
+    # Frame setup:
+    # odom -> base_link should come from wheel odom or EKF.
+    # map -> odom is produced by slam_toolbox.
     odom_frame: odom
     map_frame: map
     base_frame: base_link
+
+    # RPLIDAR scan topic.
     scan_topic: /scan
 
-    # Unity publishes odom -> base_link. SLAM publishes map -> odom.
-    transform_publish_period: 0.02
-    map_update_interval: 1.0
-    resolution: 0.05
-    max_laser_range: 30.0
-    minimum_time_interval: 0.05
-    transform_timeout: 0.3
-    tf_buffer_duration: 30.0
-    throttle_scans: 1
+    # How often slam_toolbox publishes the map -> odom transform.
+    # Lower is smoother in RViz but costs more CPU.
+    transform_publish_period: 0.05
 
+    # How often the occupancy grid /map is updated.
+    map_update_interval: 1.0
+
+    # Map cell size in metres. 0.05 means 5 cm per grid cell.
+    resolution: 0.05
+
+    # Ignore laser readings beyond this range.
+    max_laser_range: 8.0
+
+    # Minimum time between scans accepted by SLAM.
+    # Increase this to reduce CPU load.
+    minimum_time_interval: 0.1
+
+    # Time allowed when waiting for TF transforms.
+    transform_timeout: 0.3
+
+    # How long TF history is kept for scan matching.
+    tf_buffer_duration: 30.0
+
+    # Process every scan. Increase to 2 or 3 to reduce CPU load.
+    throttle_scans: 2
+
+    # Optimisation backend.
     solver_plugin: solver_plugins::CeresSolver
     ceres_linear_solver: SPARSE_NORMAL_CHOLESKY
     ceres_preconditioner: SCHUR_JACOBI
@@ -25,34 +50,86 @@ slam_toolbox:
     ceres_dogleg_type: TRADITIONAL_DOGLEG
     ceres_loss_function: None
 
+    # Enable scan-to-map matching to correct odom drift.
     use_scan_matching: true
+
+    # Uses the scan centre of mass as part of matching.
     use_scan_barycenter: true
-    minimum_travel_distance: 0.05
-    minimum_travel_heading: 0.05
+
+    # Add a new scan only after moving this far.
+    minimum_travel_distance: 0.2
+
+    # Add a new scan only after rotating this much, radians.
+    minimum_travel_heading: 0.2
+
+    # Number of recent scans kept for local matching.
     scan_buffer_size: 10
+
+    # Maximum scan distance used in the scan buffer.
     scan_buffer_maximum_scan_distance: 10.0
+
+    # Minimum match confidence for local fine scan matching.
     link_match_minimum_response_fine: 0.1
+
+    # Maximum distance between linked scans.
     link_scan_maximum_distance: 1.5
 
+    # Loop closure can fix drift, but can also cause large pose jumps if false matches occur.
     do_loop_closing: true
-    loop_search_maximum_distance: 3.0
-    loop_match_minimum_chain_size: 10
-    loop_match_maximum_variance_coarse: 3.0
-    loop_match_minimum_response_coarse: 0.35
-    loop_match_minimum_response_fine: 0.45
 
+    # Maximum distance to search for loop closures.
+    loop_search_maximum_distance: 1.5
+
+    # Minimum number of linked scans before accepting a loop closure candidate.
+    loop_match_minimum_chain_size: 15
+
+    # Coarse loop match variance threshold. Lower is stricter.
+    loop_match_maximum_variance_coarse: 1.0
+
+    # Minimum confidence for coarse loop closure matching.
+    loop_match_minimum_response_coarse: 0.55
+
+    # Minimum confidence for fine loop closure matching.
+    loop_match_minimum_response_fine: 0.65
+
+    # Local scan matching search window, metres.
     correlation_search_space_dimension: 0.5
+
+    # Resolution of the local scan matching search.
     correlation_search_space_resolution: 0.01
+
+    # Smearing helps tolerate noisy scans. Higher is more forgiving.
     correlation_search_space_smear_deviation: 0.1
-    loop_search_space_dimension: 8.0
+
+    # Loop closure search window, metres.
+    loop_search_space_dimension: 3.0
+
+    # Resolution of the loop closure search.
     loop_search_space_resolution: 0.05
+
+    # Smearing used during loop closure search.
     loop_search_space_smear_deviation: 0.03
 
+    # Penalty for scan matches that require large translation corrections.
     distance_variance_penalty: 0.5
+
+    # Penalty for scan matches that require large rotation corrections.
     angle_variance_penalty: 1.0
+
+    # Fine angular search step, radians.
     fine_search_angle_offset: 0.00349
+
+    # Coarse angular search range/step basis, radians.
     coarse_search_angle_offset: 0.349
+
+    # Coarse angular search resolution, radians.
     coarse_angle_resolution: 0.0349
+
+    # Minimum angular penalty applied during matching.
     minimum_angle_penalty: 0.9
+
+    # Minimum distance penalty applied during matching.
     minimum_distance_penalty: 0.5
+
+    # Expands acceptable responses around good matches.
     use_response_expansion: true

--- a/rugged_rover_control/config/controllers.yaml
+++ b/rugged_rover_control/config/controllers.yaml
@@ -25,10 +25,10 @@ diff_drive_controller:
     right_wheel_names: ["front_right_joint", "rear_right_joint"]
     # Effective skid-steer track width calibrated from 360 degree rotation test.
     # Physical rear wheel center distance is ~0.355 m.
-    wheel_separation: 0.652
-    wheel_radius: 0.060
+    wheel_separation: 0.475
+    wheel_radius: 0.082
     use_stamped_vel: false
     base_frame_id: base_link
     cmd_vel_timeout: 0.25
     publish_rate: 30.0
-    enable_odom_tf: true
+    enable_odom_tf: false

--- a/rugged_rover_hardware_interfaces/include/rugged_rover_hardware_interfaces/sabertooth/sabertooth_system_interface.hpp
+++ b/rugged_rover_hardware_interfaces/include/rugged_rover_hardware_interfaces/sabertooth/sabertooth_system_interface.hpp
@@ -3,9 +3,11 @@
 #ifndef RUGGED_ROVER_HARDWARE_INTERFACES_SABERTOOTH_SYSTEM_INTERFACE_HPP
 #define RUGGED_ROVER_HARDWARE_INTERFACES_SABERTOOTH_SYSTEM_INTERFACE_HPP
 
+#include <atomic>
 #include <memory>
 #include <mutex>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "hardware_interface/system_interface.hpp"
@@ -71,9 +73,13 @@ namespace rugged_rover_hardware_interfaces::sabertooth
     double feedback_timeout_seconds_ = 0.25;
     bool use_reliable_command_qos_ = false;
     rclcpp::Time last_command_publish_time_;
-    double command_publish_period_seconds_ = 0.05;
+    double command_publish_period_seconds_ = 0.02;
     std::mutex feedback_mutex_;
     std::atomic<bool> battery_allows_motion_ = true;
+
+    rclcpp::executors::SingleThreadedExecutor::SharedPtr executor_;
+    std::thread executor_thread_;
+    std::atomic<bool> executor_running_ = false;
 
     friend class SabertoothInterfaceTest;
   };

--- a/rugged_rover_hardware_interfaces/src/sabertooth/sabertooth_system_interface.cpp
+++ b/rugged_rover_hardware_interfaces/src/sabertooth/sabertooth_system_interface.cpp
@@ -1,7 +1,9 @@
 #include "rugged_rover_hardware_interfaces/sabertooth/sabertooth_system_interface.hpp"
 
 #include <algorithm>
+#include <chrono>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
@@ -101,9 +103,23 @@ namespace rugged_rover_hardware_interfaces::sabertooth
     RCLCPP_INFO(this->logger_, "Using %s QoS for platform motor commands",
                 use_reliable_command_qos_ ? "reliable" : "best_effort");
 
-    cmd_pub_ = node_->create_publisher<sensor_msgs::msg::JointState>("platform/motors/cmd",
-                                                                     command_qos);
+    cmd_pub_ =
+        node_->create_publisher<sensor_msgs::msg::JointState>("platform/motors/cmd", command_qos);
     last_command_publish_time_ = node_->now();
+
+    executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+    executor_->add_node(node_);
+
+    executor_running_.store(true);
+    executor_thread_ = std::thread(
+        [this]()
+        {
+          while (executor_running_.load() && rclcpp::ok())
+          {
+            executor_->spin_some(std::chrono::milliseconds(5));
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+          }
+        });
 
     // Return success if activation is complete
     return hardware_interface::CallbackReturn::SUCCESS;
@@ -130,6 +146,23 @@ namespace rugged_rover_hardware_interfaces::sabertooth
     battery_critical_sub_.reset();
     cmd_pub_.reset();
     node_.reset();
+
+    executor_running_.store(false);
+    if (executor_)
+    {
+      executor_->cancel();
+    }
+    if (executor_thread_.joinable())
+    {
+      executor_thread_.join();
+    }
+
+    if (executor_ && node_)
+    {
+      executor_->remove_node(node_);
+    }
+
+    executor_.reset();
 
     // Return success if deactivation is complete
     return hardware_interface::CallbackReturn::SUCCESS;
@@ -197,10 +230,6 @@ namespace rugged_rover_hardware_interfaces::sabertooth
   hardware_interface::return_type SabertoothSystemInterface::read(const rclcpp::Time&,
                                                                   const rclcpp::Duration&)
   {
-    if (node_)
-    {
-      rclcpp::spin_some(node_);
-    }
 
     std::lock_guard<std::mutex> lock(feedback_mutex_);
 
@@ -279,6 +308,8 @@ namespace rugged_rover_hardware_interfaces::sabertooth
     if (!battery_allows_motion_.load())
     {
       cmd_msg.velocity.assign(joint_names_.size(), 0.0);
+      RCLCPP_WARN(this->logger_,
+                  "Battery is critical, not sending motor commands to prevent brownout.");
     }
     else
     {


### PR DESCRIPTION
# Rugged Rover Bringup, Tuning, and Pi Bootstrap Updates

## Summary

This PR rolls up the latest real-robot bringup work for the A4WD3 Rugged Rover. It improves IMU reliability, cleans up firmware debug output, updates the motor model to match the actual gearbox hardware, tunes SLAM/Nav2, and adds clearer setup documentation plus a Raspberry Pi bootstrap path for new installs.

## Changes

- Hardened Razor IMU firmware serial logging so the IMU stream is more reliable during bringup.
- Gated firmware debug statements so normal ROS/micro-ROS operation is not polluted by serial debug output.
- Updated motor gearbox specs to match the actual 51:1 motor hardware.
- Tuned SLAM configuration, including loop closure behavior, for more stable real-world mapping.
- Tuned Nav2 behavior for the current rover setup.
- Updated the README with more detailed A4WD3 setup and bringup instructions.
- Added a `rugged_rover_bootstrap` folder for Raspberry Pi setup automation.
- Added a Pi bootstrap script targeting Ubuntu 24.04 and ROS 2 Jazzy, including handling for the previous `bzip2`/`noble-updates` apt issue.

## Validation

- Verified motor control after updating gearbox scaling.
- Tested SLAM mapping on the real rover.
- Validated IMU publishing after firmware/node updates.
- Tested Nav2 behavior on the Raspberry Pi 5.
- Confirmed README/bootstrap changes describe the current setup path.

## Notes

The rover is now running on a Raspberry Pi 5, which gives the stack more headroom for SLAM, Nav2, lidar, RealSense, ros2_control, and micro-ROS running together.
