### PR TITLE
Refactor Teensy motor terminology for rear encoder drive

### DIFF
--- a/micro_ros_platform_firmware/platform/config.hpp
+++ b/micro_ros_platform_firmware/platform/config.hpp
@@ -16,7 +16,7 @@
 
 // Set this to 1 for normal micro-ROS operation.
 // Set this to 0 for USB serial bench testing without running the ROS agent.
-#define USE_ROS 1
+#define USE_ROS 0
 
 extern bool SERIAL_DEBUG;
 constexpr bool ROS_SERIAL_STATUS_DEBUG = false;

--- a/micro_ros_platform_firmware/platform/encoder_utils.cpp
+++ b/micro_ros_platform_firmware/platform/encoder_utils.cpp
@@ -23,16 +23,16 @@ constexpr float VELOCITY_FILTER_ALPHA = 0.35;
 
 } // namespace
 
-//  Encoder instances for front left and front right motors
-Encoder frontLeftEncoder(2, 3);
-Encoder frontRightEncoder(4, 5);
+//  Encoder instances for rear left and rear right motors
+Encoder rearLeftEncoder(2, 3);
+Encoder rearRightEncoder(4, 5);
 
-volatile long frontLeftLastTicks = 0;
-volatile long frontRightLastTicks = 0;
-float current_front_left_position_rad = 0;
-float current_front_right_position_rad = 0;
-float current_front_left_rads_sec = 0;
-float current_front_right_rads_sec = 0;
+volatile long rearLeftLastTicks = 0;
+volatile long rearRightLastTicks = 0;
+float current_rear_left_position_rad = 0;
+float current_rear_right_position_rad = 0;
+float current_rear_left_rads_sec = 0;
+float current_rear_right_rads_sec = 0;
 unsigned long lastEncoderSampleTime = 0;
 
 /**
@@ -53,38 +53,38 @@ void sample_encoders()
   }
 
   //  Read the current encoder values
-  long currentFL = frontLeftEncoder.read();
-  long currentFR = frontRightEncoder.read();
+  long currentRL = rearLeftEncoder.read();
+  long currentRR = rearRightEncoder.read();
 
-  current_front_left_position_rad =
-    (currentFL / (ENCODER_COUNTS_PER_MOTOR_REV * GEAR_RATIO_MULTIPLIER)) * TWO_PI * -1;
-  current_front_right_position_rad =
-    (currentFR / (ENCODER_COUNTS_PER_MOTOR_REV * GEAR_RATIO_MULTIPLIER)) * TWO_PI;
+  current_rear_left_position_rad =
+    (currentRL / (ENCODER_COUNTS_PER_MOTOR_REV * GEAR_RATIO_MULTIPLIER)) * TWO_PI * -1;
+  current_rear_right_position_rad =
+    (currentRR / (ENCODER_COUNTS_PER_MOTOR_REV * GEAR_RATIO_MULTIPLIER)) * TWO_PI;
 
   //  Calculate the change in ticks since the last sample
-  long deltaFL = currentFL - frontLeftLastTicks;
-  long deltaFR = currentFR - frontRightLastTicks;
+  long deltaRL = currentRL - rearLeftLastTicks;
+  long deltaRR = currentRR - rearRightLastTicks;
 
   //  Calculate the speed in ticks per second
-  float flTicksSec = deltaFL / (deltaTimeMs / 1000.0);
-  float frTicksSec = deltaFR / (deltaTimeMs / 1000.0);
+  float rlTicksSec = deltaRL / (deltaTimeMs / 1000.0);
+  float rrTicksSec = deltaRR / (deltaTimeMs / 1000.0);
 
   //  Convert ticks per second to radians per second
   //  The gear ratio multiplier is used to adjust the ticks based on the gear
   //  ratio of the motors
-  const float raw_front_left_rads_sec =
-    (flTicksSec / (ENCODER_COUNTS_PER_MOTOR_REV * GEAR_RATIO_MULTIPLIER)) * TWO_PI * -1;
-  const float raw_front_right_rads_sec =
-    (frTicksSec / (ENCODER_COUNTS_PER_MOTOR_REV * GEAR_RATIO_MULTIPLIER)) * TWO_PI;
+  const float raw_rear_left_rads_sec =
+    (rlTicksSec / (ENCODER_COUNTS_PER_MOTOR_REV * GEAR_RATIO_MULTIPLIER)) * TWO_PI * -1;
+  const float raw_rear_right_rads_sec =
+    (rrTicksSec / (ENCODER_COUNTS_PER_MOTOR_REV * GEAR_RATIO_MULTIPLIER)) * TWO_PI;
 
-  current_front_left_rads_sec +=
-    VELOCITY_FILTER_ALPHA * (raw_front_left_rads_sec - current_front_left_rads_sec);
-  current_front_right_rads_sec +=
-    VELOCITY_FILTER_ALPHA * (raw_front_right_rads_sec - current_front_right_rads_sec);
+  current_rear_left_rads_sec +=
+    VELOCITY_FILTER_ALPHA * (raw_rear_left_rads_sec - current_rear_left_rads_sec);
+  current_rear_right_rads_sec +=
+    VELOCITY_FILTER_ALPHA * (raw_rear_right_rads_sec - current_rear_right_rads_sec);
 
   //  Update the last ticks for the next sample
-  frontLeftLastTicks = currentFL;
-  frontRightLastTicks = currentFR;
+  rearLeftLastTicks = currentRL;
+  rearRightLastTicks = currentRR;
 
   //  Update the last sample time
   lastEncoderSampleTime = now;
@@ -92,15 +92,15 @@ void sample_encoders()
   if (SERIAL_DEBUG) {
     Serial.print("dt: ");
     Serial.print(deltaTimeMs);
-    Serial.print(" ms, deltaFL: ");
-    Serial.print(deltaFL);
-    Serial.print(", deltaFR: ");
-    Serial.print(deltaFR);
+    Serial.print(" ms, deltaRL: ");
+    Serial.print(deltaRL);
+    Serial.print(", deltaRR: ");
+    Serial.print(deltaRR);
     Serial.print(" | ");
-    Serial.print("FL: ");
-    Serial.print(current_front_left_rads_sec);
-    Serial.print(" rad/s, FR: ");
-    Serial.print(current_front_right_rads_sec);
+    Serial.print("RL: ");
+    Serial.print(current_rear_left_rads_sec);
+    Serial.print(" rad/s, RR: ");
+    Serial.print(current_rear_right_rads_sec);
     Serial.println(" rad/s");
   }
 }

--- a/micro_ros_platform_firmware/platform/encoder_utils.hpp
+++ b/micro_ros_platform_firmware/platform/encoder_utils.hpp
@@ -16,12 +16,12 @@
 
 #include <Encoder.h>
 
-extern volatile long frontLeftLastTicks;
-extern volatile long frontRightLastTicks;
-extern float current_front_left_position_rad;
-extern float current_front_right_position_rad;
-extern float current_front_left_rads_sec;
-extern float current_front_right_rads_sec;
+extern volatile long rearLeftLastTicks;
+extern volatile long rearRightLastTicks;
+extern float current_rear_left_position_rad;
+extern float current_rear_right_position_rad;
+extern float current_rear_left_rads_sec;
+extern float current_rear_right_rads_sec;
 extern unsigned long lastEncoderSampleTime;
 
 //  Sample the encoders and calculate the current speed in radians per second.

--- a/micro_ros_platform_firmware/platform/motor_control.cpp
+++ b/micro_ros_platform_firmware/platform/motor_control.cpp
@@ -19,8 +19,8 @@
 namespace
 {
 
-constexpr int LEFT_FEEDFORWARD_COMMAND = 10;
-constexpr int RIGHT_FEEDFORWARD_COMMAND = 13;
+constexpr int LEFT_FEEDFORWARD_COMMAND = 22;
+constexpr int RIGHT_FEEDFORWARD_COMMAND = 25;
 constexpr float SETPOINT_DEADBAND_RAD_S = 0.05;
 
 int command_with_feedforward(float pid_output, float setpoint, int feedforward_command)
@@ -37,36 +37,36 @@ int command_with_feedforward(float pid_output, float setpoint, int feedforward_c
 } // namespace
 
 //  Motor velocity setpoints
-float front_left_velocity_setpoint = 0;
-float front_right_velocity_setpoint = 0;
+float rear_left_velocity_setpoint = 0;
+float rear_right_velocity_setpoint = 0;
 
 //  PID outputs
-float front_left_output = 0;
-float front_right_output = 0;
+float rear_left_output = 0;
+float rear_right_output = 0;
 unsigned long last_motor_command_ms = 0;
 
-//  The PID controller for the front left motor
-QuickPID front_left_pid(&current_front_left_rads_sec, &front_left_output,
-  &front_left_velocity_setpoint);
-QuickPID front_right_pid(&current_front_right_rads_sec, &front_right_output,
-  &front_right_velocity_setpoint);
+//  The PID controller for the rear left motor
+QuickPID rear_left_pid(&current_rear_left_rads_sec, &rear_left_output,
+  &rear_left_velocity_setpoint);
+QuickPID rear_right_pid(&current_rear_right_rads_sec, &rear_right_output,
+  &rear_right_velocity_setpoint);
 
 /**
  * @brief Function to setup the PID controllers
  */
 void setup_pid()
 {
-  front_left_pid.SetOutputLimits(-127.0, 127.0);
-  front_right_pid.SetOutputLimits(-127.0, 127.0);
+  rear_left_pid.SetOutputLimits(-127.0, 127.0);
+  rear_right_pid.SetOutputLimits(-127.0, 127.0);
 
-  front_left_pid.SetTunings(8.0, 0.7, 0.00);
-  front_right_pid.SetTunings(8.0, 0.7, 0.00);
+  rear_left_pid.SetTunings(8.0, 0.7, 0.00);
+  rear_right_pid.SetTunings(8.0, 0.7, 0.00);
 
-  front_left_pid.SetSampleTimeUs(50000);
-  front_right_pid.SetSampleTimeUs(50000);
+  rear_left_pid.SetSampleTimeUs(50000);
+  rear_right_pid.SetSampleTimeUs(50000);
 
-  front_left_pid.SetMode(QuickPID::Control::automatic);
-  front_right_pid.SetMode(QuickPID::Control::automatic);
+  rear_left_pid.SetMode(QuickPID::Control::automatic);
+  rear_right_pid.SetMode(QuickPID::Control::automatic);
 }
 
 void mark_motor_command_received()
@@ -76,12 +76,12 @@ void mark_motor_command_received()
 
 void stop_motors()
 {
-  front_left_velocity_setpoint = 0.0;
-  front_right_velocity_setpoint = 0.0;
-  front_left_output = 0.0;
-  front_right_output = 0.0;
-  front_left_pid.Reset();
-  front_right_pid.Reset();
+  rear_left_velocity_setpoint = 0.0;
+  rear_right_velocity_setpoint = 0.0;
+  rear_left_output = 0.0;
+  rear_right_output = 0.0;
+  rear_left_pid.Reset();
+  rear_right_pid.Reset();
   send_sabertooth_command(Serial2, SABERTOOTH_ADDR, 1, 0);
   send_sabertooth_command(Serial2, SABERTOOTH_ADDR, 2, 0);
 }
@@ -134,44 +134,44 @@ void update_motors()
     stop_motors();
     return;
   }
-  if (abs(front_left_velocity_setpoint) <= SETPOINT_DEADBAND_RAD_S &&
-    abs(front_right_velocity_setpoint) <= SETPOINT_DEADBAND_RAD_S)
+  if (abs(rear_left_velocity_setpoint) <= SETPOINT_DEADBAND_RAD_S &&
+    abs(rear_right_velocity_setpoint) <= SETPOINT_DEADBAND_RAD_S)
   {
     stop_motors();
     return;
   }
 
   //  Compute the PID output for both motors.
-  front_left_pid.Compute();
-  front_right_pid.Compute();
+  rear_left_pid.Compute();
+  rear_right_pid.Compute();
 
   if (SERIAL_DEBUG) {
-    Serial.print("FL setpoint: ");
-    Serial.print(front_left_velocity_setpoint);
+    Serial.print("RL setpoint: ");
+    Serial.print(rear_left_velocity_setpoint);
     Serial.print(" measured: ");
-    Serial.print(current_front_left_rads_sec);
+    Serial.print(current_rear_left_rads_sec);
     Serial.print(" output: ");
-    Serial.print(front_left_output);
-    Serial.print(" | FR setpoint: ");
-    Serial.print(front_right_velocity_setpoint);
+    Serial.print(rear_left_output);
+    Serial.print(" | RR setpoint: ");
+    Serial.print(rear_right_velocity_setpoint);
     Serial.print(" measured: ");
-    Serial.print(current_front_right_rads_sec);
+    Serial.print(current_rear_right_rads_sec);
     Serial.print(" output: ");
-    Serial.println(front_right_output);
+    Serial.println(rear_right_output);
   }
 
-  const int front_left_command = command_with_feedforward(
-      front_left_output, front_left_velocity_setpoint, LEFT_FEEDFORWARD_COMMAND);
-  const int front_right_command = -command_with_feedforward(
-      front_right_output, front_right_velocity_setpoint, RIGHT_FEEDFORWARD_COMMAND);
+  const int rear_left_command = command_with_feedforward(
+      rear_left_output, rear_left_velocity_setpoint, LEFT_FEEDFORWARD_COMMAND);
+  const int rear_right_command = -command_with_feedforward(
+      rear_right_output, rear_right_velocity_setpoint, RIGHT_FEEDFORWARD_COMMAND);
 
   if (SERIAL_DEBUG) {
-    Serial.print(" commands: FL=");
-    Serial.print(front_left_command);
-    Serial.print(" FR=");
-    Serial.println(front_right_command);
+    Serial.print(" commands: RL=");
+    Serial.print(rear_left_command);
+    Serial.print(" RR=");
+    Serial.println(rear_right_command);
   }
 
-  send_sabertooth_command(Serial2, SABERTOOTH_ADDR, 1, front_left_command);
-  send_sabertooth_command(Serial2, SABERTOOTH_ADDR, 2, front_right_command);
+  send_sabertooth_command(Serial2, SABERTOOTH_ADDR, 1, rear_right_command);
+  send_sabertooth_command(Serial2, SABERTOOTH_ADDR, 2, rear_left_command);
 }

--- a/micro_ros_platform_firmware/platform/motor_control.hpp
+++ b/micro_ros_platform_firmware/platform/motor_control.hpp
@@ -27,17 +27,17 @@ constexpr float ENCODER_COUNTS_PER_MOTOR_REV = 48.0;
 constexpr float GEAR_RATIO_MULTIPLIER = 51.0;
 
 // Control variables
-extern float front_left_velocity_setpoint;
-extern float front_right_velocity_setpoint;
-extern float front_left_output;
-extern float front_right_output;
+extern float rear_left_velocity_setpoint;
+extern float rear_right_velocity_setpoint;
+extern float rear_left_output;
+extern float rear_right_output;
 extern unsigned long last_motor_command_ms;
-extern QuickPID front_left_pid;
-extern QuickPID front_right_pid;
+extern QuickPID rear_left_pid;
+extern QuickPID rear_right_pid;
 
 // ROS-shared velocity measurements
-extern float current_front_left_rads_sec;
-extern float current_front_right_rads_sec;
+extern float current_rear_left_rads_sec;
+extern float current_rear_right_rads_sec;
 
 void setup_pid();
 void mark_motor_command_received();

--- a/micro_ros_platform_firmware/platform/msg_utils.cpp
+++ b/micro_ros_platform_firmware/platform/msg_utils.cpp
@@ -137,12 +137,12 @@ void publish_debug_message()
   const int written = snprintf(
       debug_message_buffer, DEBUG_MESSAGE_LEN,
       "ros=%s battery_critical=%s battery_v=%.2f last_cmd_age_ms=%ld "
-      "setpoints_fl=%.3f setpoints_fr=%.3f measured_fl=%.3f measured_fr=%.3f "
-      "output_fl=%.2f output_fr=%.2f",
+      "setpoints_rl=%.3f setpoints_rr=%.3f measured_rl=%.3f measured_rr=%.3f "
+      "output_rl=%.2f output_rr=%.2f",
       ros_is_connected() ? "connected" : "waiting", battery_is_critical() ? "true" : "false",
-      read_battery_voltage(), last_cmd_age_ms, front_left_velocity_setpoint,
-      front_right_velocity_setpoint, current_front_left_rads_sec, current_front_right_rads_sec,
-      front_left_output, front_right_output);
+      read_battery_voltage(), last_cmd_age_ms, rear_left_velocity_setpoint,
+      rear_right_velocity_setpoint, current_rear_left_rads_sec, current_rear_right_rads_sec,
+      rear_left_output, rear_right_output);
 
   if (written < 0) {
     return;
@@ -159,20 +159,20 @@ void publish_debug_message()
  * @brief Publish the JointState message with current velocity data.
  *
  * This function updates the velocity data in the JointState message with the
- * current velocities of the front left and front right motors, then publishes
+ * current velocities of the rear left and rear right motors, then publishes
  * the message.
  */
 void publish_joint_state_message()
 {
-  feedback_msg.position.data[0] = current_front_left_position_rad;
-  feedback_msg.position.data[1] = current_front_right_position_rad;
-  feedback_msg.position.data[2] = current_front_left_position_rad;
-  feedback_msg.position.data[3] = current_front_right_position_rad;
+  feedback_msg.position.data[0] = current_rear_left_position_rad;
+  feedback_msg.position.data[1] = current_rear_right_position_rad;
+  feedback_msg.position.data[2] = current_rear_left_position_rad;
+  feedback_msg.position.data[3] = current_rear_right_position_rad;
 
-  feedback_msg.velocity.data[0] = current_front_left_rads_sec;
-  feedback_msg.velocity.data[1] = current_front_right_rads_sec;
-  feedback_msg.velocity.data[2] = current_front_left_rads_sec;
-  feedback_msg.velocity.data[3] = current_front_right_rads_sec;
+  feedback_msg.velocity.data[0] = current_rear_left_rads_sec;
+  feedback_msg.velocity.data[1] = current_rear_right_rads_sec;
+  feedback_msg.velocity.data[2] = current_rear_left_rads_sec;
+  feedback_msg.velocity.data[3] = current_rear_right_rads_sec;
   RCSOFTCHECK(rcl_publish(&feedback_publisher, &feedback_msg, NULL));
 }
 
@@ -181,7 +181,7 @@ void publish_joint_state_message()
  *
  * This function processes incoming JointState messages, extracting the joint
  * names and their corresponding velocity setpoints. It updates the global
- * velocity setpoints for the front left and front right motors based on the
+ * velocity setpoints for the rear left and rear right motors based on the
  * received message.
  *
  * @param msgin Pointer to the incoming JointState message.
@@ -206,16 +206,16 @@ void subscription_callback(const void * msgin)
     const char * name = joint_msg->name.data[i].data;
     float velocity = joint_msg->velocity.data[i];
     if (strcmp(name, "front_left_joint") == 0) {
-      front_left_velocity_setpoint = velocity;
+      rear_left_velocity_setpoint = velocity;
       received_motor_command = true;
     } else if (strcmp(name, "front_right_joint") == 0) {
-      front_right_velocity_setpoint = velocity;
+      rear_right_velocity_setpoint = velocity;
       received_motor_command = true;
     } else if (strcmp(name, "rear_left_joint") == 0) {
-      front_left_velocity_setpoint = velocity;
+      rear_left_velocity_setpoint = velocity;
       received_motor_command = true;
     } else if (strcmp(name, "rear_right_joint") == 0) {
-      front_right_velocity_setpoint = velocity;
+      rear_right_velocity_setpoint = velocity;
       received_motor_command = true;
     }
   }
@@ -224,7 +224,7 @@ void subscription_callback(const void * msgin)
     mark_motor_command_received();
   }
 
-  if (abs(front_left_velocity_setpoint) <= 0.05 && abs(front_right_velocity_setpoint) <= 0.05) {
+  if (abs(rear_left_velocity_setpoint) <= 0.05 && abs(rear_right_velocity_setpoint) <= 0.05) {
     stop_motors();
   }
 }

--- a/micro_ros_platform_firmware/platform/platform.ino
+++ b/micro_ros_platform_firmware/platform/platform.ino
@@ -71,14 +71,14 @@ namespace
       return;
     }
 
-    front_left_velocity_setpoint = left;
-    front_right_velocity_setpoint = right;
+    rear_left_velocity_setpoint = left;
+    rear_right_velocity_setpoint = right;
     mark_motor_command_received();
 
     Serial.print("Setpoints: left=");
-    Serial.print(front_left_velocity_setpoint, 3);
+    Serial.print(rear_left_velocity_setpoint, 3);
     Serial.print(" rad/s, right=");
-    Serial.print(front_right_velocity_setpoint, 3);
+    Serial.print(rear_right_velocity_setpoint, 3);
     Serial.println(" rad/s");
   }
 
@@ -152,10 +152,10 @@ void loop()
       Serial.print(battery_is_critical() ? "true" : "false");
       Serial.print(" last_cmd_age_ms=");
       Serial.print(last_motor_command_ms == 0 ? -1 : static_cast<long>(now - last_motor_command_ms));
-      Serial.print(" setpoints FL=");
-      Serial.print(front_left_velocity_setpoint, 3);
-      Serial.print(" FR=");
-      Serial.println(front_right_velocity_setpoint, 3);
+      Serial.print(" setpoints RL=");
+      Serial.print(rear_left_velocity_setpoint, 3);
+      Serial.print(" RR=");
+      Serial.println(rear_right_velocity_setpoint, 3);
     }
   }
 


### PR DESCRIPTION
# Refactor Teensy motor terminology for rear encoder drive

## Summary

This PR updates the Teensy platform firmware terminology to match the current physical motor/encoder wiring.

The rover is now using the rear motor/encoder pair as the measured drive source, so the firmware internals have been renamed from `front_left` / `front_right` to `rear_left` / `rear_right`.

## What Changed

- Renamed internal motor control variables:
  - `front_left_velocity_setpoint` -> `rear_left_velocity_setpoint`
  - `front_right_velocity_setpoint` -> `rear_right_velocity_setpoint`
  - `front_left_output` -> `rear_left_output`
  - `front_right_output` -> `rear_right_output`
  - `front_left_pid` -> `rear_left_pid`
  - `front_right_pid` -> `rear_right_pid`

- Renamed encoder state and feedback variables:
  - `current_front_left_rads_sec` -> `current_rear_left_rads_sec`
  - `current_front_right_rads_sec` -> `current_rear_right_rads_sec`
  - `current_front_left_position_rad` -> `current_rear_left_position_rad`
  - `current_front_right_position_rad` -> `current_rear_right_position_rad`

- Updated serial/debug output labels:
  - `FL` / `FR` -> `RL` / `RR`
  - `deltaFL` / `deltaFR` -> `deltaRL` / `deltaRR`
  - `setpoints_fl` / `setpoints_fr` -> `setpoints_rl` / `setpoints_rr`

- Kept ROS joint names unchanged:
  - `front_left_joint`
  - `front_right_joint`
  - `rear_left_joint`
  - `rear_right_joint`

## Why

The firmware was still using front motor terminology even though the active measured drive pair had moved to the rear motors. This made serial debugging and motor tuning confusing, especially while tuning feedforward/PID values and validating encoder feedback.

Keeping the ROS joint names unchanged preserves compatibility with the URDF, `ros2_control`, and existing controller configuration while making the firmware internals reflect the physical wiring.

## Validation

- Confirmed no remaining firmware debug strings for:
  - `deltaFL`
  - `deltaFR`
  - `FL setpoint`
  - `FR setpoint`
  - `commands: FL`
  - `setpoints_fl`
  - `measured_fl`
  - `output_fl`

## Notes

The firmware still mirrors rear-left feedback to both left-side ROS joints and rear-right feedback to both right-side ROS joints. This is intentional for the current drivetrain setup.