### PR TITLE
Refactors the Teensy platform firmware terminology.

### DIFF
--- a/micro_ros_platform_firmware/platform/config.hpp
+++ b/micro_ros_platform_firmware/platform/config.hpp
@@ -16,7 +16,7 @@
 
 // Set this to 1 for normal micro-ROS operation.
 // Set this to 0 for USB serial bench testing without running the ROS agent.
-#define USE_ROS 0
+#define USE_ROS 1
 
 extern bool SERIAL_DEBUG;
 constexpr bool ROS_SERIAL_STATUS_DEBUG = false;

--- a/micro_ros_platform_firmware/platform/encoder_utils.cpp
+++ b/micro_ros_platform_firmware/platform/encoder_utils.cpp
@@ -23,16 +23,16 @@ constexpr float VELOCITY_FILTER_ALPHA = 0.35;
 
 } // namespace
 
-//  Encoder instances for rear left and rear right motors
-Encoder rearLeftEncoder(2, 3);
-Encoder rearRightEncoder(4, 5);
+//  Encoder instances for the left and right drivetrain sides
+Encoder leftSideEncoder(2, 3);
+Encoder rightSideEncoder(4, 5);
 
-volatile long rearLeftLastTicks = 0;
-volatile long rearRightLastTicks = 0;
-float current_rear_left_position_rad = 0;
-float current_rear_right_position_rad = 0;
-float current_rear_left_rads_sec = 0;
-float current_rear_right_rads_sec = 0;
+volatile long leftSideLastTicks = 0;
+volatile long rightSideLastTicks = 0;
+float current_left_side_position_rad = 0;
+float current_right_side_position_rad = 0;
+float current_left_side_rads_sec = 0;
+float current_right_side_rads_sec = 0;
 unsigned long lastEncoderSampleTime = 0;
 
 /**
@@ -53,38 +53,38 @@ void sample_encoders()
   }
 
   //  Read the current encoder values
-  long currentRL = rearLeftEncoder.read();
-  long currentRR = rearRightEncoder.read();
+  long currentLeftSide = leftSideEncoder.read();
+  long currentRightSide = rightSideEncoder.read();
 
-  current_rear_left_position_rad =
-    (currentRL / (ENCODER_COUNTS_PER_MOTOR_REV * GEAR_RATIO_MULTIPLIER)) * TWO_PI * -1;
-  current_rear_right_position_rad =
-    (currentRR / (ENCODER_COUNTS_PER_MOTOR_REV * GEAR_RATIO_MULTIPLIER)) * TWO_PI;
+  current_left_side_position_rad =
+    (currentLeftSide / (ENCODER_COUNTS_PER_MOTOR_REV * GEAR_RATIO_MULTIPLIER)) * TWO_PI * -1;
+  current_right_side_position_rad =
+    (currentRightSide / (ENCODER_COUNTS_PER_MOTOR_REV * GEAR_RATIO_MULTIPLIER)) * TWO_PI;
 
   //  Calculate the change in ticks since the last sample
-  long deltaRL = currentRL - rearLeftLastTicks;
-  long deltaRR = currentRR - rearRightLastTicks;
+  long deltaLeftSide = currentLeftSide - leftSideLastTicks;
+  long deltaRightSide = currentRightSide - rightSideLastTicks;
 
   //  Calculate the speed in ticks per second
-  float rlTicksSec = deltaRL / (deltaTimeMs / 1000.0);
-  float rrTicksSec = deltaRR / (deltaTimeMs / 1000.0);
+  float leftSideTicksSec = deltaLeftSide / (deltaTimeMs / 1000.0);
+  float rightSideTicksSec = deltaRightSide / (deltaTimeMs / 1000.0);
 
   //  Convert ticks per second to radians per second
   //  The gear ratio multiplier is used to adjust the ticks based on the gear
   //  ratio of the motors
-  const float raw_rear_left_rads_sec =
-    (rlTicksSec / (ENCODER_COUNTS_PER_MOTOR_REV * GEAR_RATIO_MULTIPLIER)) * TWO_PI * -1;
-  const float raw_rear_right_rads_sec =
-    (rrTicksSec / (ENCODER_COUNTS_PER_MOTOR_REV * GEAR_RATIO_MULTIPLIER)) * TWO_PI;
+  const float raw_left_side_rads_sec =
+    (leftSideTicksSec / (ENCODER_COUNTS_PER_MOTOR_REV * GEAR_RATIO_MULTIPLIER)) * TWO_PI * -1;
+  const float raw_right_side_rads_sec =
+    (rightSideTicksSec / (ENCODER_COUNTS_PER_MOTOR_REV * GEAR_RATIO_MULTIPLIER)) * TWO_PI;
 
-  current_rear_left_rads_sec +=
-    VELOCITY_FILTER_ALPHA * (raw_rear_left_rads_sec - current_rear_left_rads_sec);
-  current_rear_right_rads_sec +=
-    VELOCITY_FILTER_ALPHA * (raw_rear_right_rads_sec - current_rear_right_rads_sec);
+  current_left_side_rads_sec +=
+    VELOCITY_FILTER_ALPHA * (raw_left_side_rads_sec - current_left_side_rads_sec);
+  current_right_side_rads_sec +=
+    VELOCITY_FILTER_ALPHA * (raw_right_side_rads_sec - current_right_side_rads_sec);
 
   //  Update the last ticks for the next sample
-  rearLeftLastTicks = currentRL;
-  rearRightLastTicks = currentRR;
+  leftSideLastTicks = currentLeftSide;
+  rightSideLastTicks = currentRightSide;
 
   //  Update the last sample time
   lastEncoderSampleTime = now;
@@ -92,15 +92,15 @@ void sample_encoders()
   if (SERIAL_DEBUG) {
     Serial.print("dt: ");
     Serial.print(deltaTimeMs);
-    Serial.print(" ms, deltaRL: ");
-    Serial.print(deltaRL);
-    Serial.print(", deltaRR: ");
-    Serial.print(deltaRR);
+    Serial.print(" ms, deltaLeft: ");
+    Serial.print(deltaLeftSide);
+    Serial.print(", deltaRight: ");
+    Serial.print(deltaRightSide);
     Serial.print(" | ");
-    Serial.print("RL: ");
-    Serial.print(current_rear_left_rads_sec);
-    Serial.print(" rad/s, RR: ");
-    Serial.print(current_rear_right_rads_sec);
+    Serial.print("Left: ");
+    Serial.print(current_left_side_rads_sec);
+    Serial.print(" rad/s, Right: ");
+    Serial.print(current_right_side_rads_sec);
     Serial.println(" rad/s");
   }
 }

--- a/micro_ros_platform_firmware/platform/encoder_utils.hpp
+++ b/micro_ros_platform_firmware/platform/encoder_utils.hpp
@@ -16,12 +16,12 @@
 
 #include <Encoder.h>
 
-extern volatile long rearLeftLastTicks;
-extern volatile long rearRightLastTicks;
-extern float current_rear_left_position_rad;
-extern float current_rear_right_position_rad;
-extern float current_rear_left_rads_sec;
-extern float current_rear_right_rads_sec;
+extern volatile long leftSideLastTicks;
+extern volatile long rightSideLastTicks;
+extern float current_left_side_position_rad;
+extern float current_right_side_position_rad;
+extern float current_left_side_rads_sec;
+extern float current_right_side_rads_sec;
 extern unsigned long lastEncoderSampleTime;
 
 //  Sample the encoders and calculate the current speed in radians per second.

--- a/micro_ros_platform_firmware/platform/motor_control.cpp
+++ b/micro_ros_platform_firmware/platform/motor_control.cpp
@@ -22,6 +22,7 @@ namespace
 constexpr int LEFT_FEEDFORWARD_COMMAND = 22;
 constexpr int RIGHT_FEEDFORWARD_COMMAND = 25;
 constexpr float SETPOINT_DEADBAND_RAD_S = 0.05;
+constexpr int DEBUG_MAX_MOTOR_COMMAND = 60;
 
 int command_with_feedforward(float pid_output, float setpoint, int feedforward_command)
 {
@@ -37,36 +38,36 @@ int command_with_feedforward(float pid_output, float setpoint, int feedforward_c
 } // namespace
 
 //  Motor velocity setpoints
-float rear_left_velocity_setpoint = 0;
-float rear_right_velocity_setpoint = 0;
+float left_side_velocity_setpoint = 0;
+float right_side_velocity_setpoint = 0;
 
 //  PID outputs
-float rear_left_output = 0;
-float rear_right_output = 0;
+float left_side_output = 0;
+float right_side_output = 0;
 unsigned long last_motor_command_ms = 0;
 
-//  The PID controller for the rear left motor
-QuickPID rear_left_pid(&current_rear_left_rads_sec, &rear_left_output,
-  &rear_left_velocity_setpoint);
-QuickPID rear_right_pid(&current_rear_right_rads_sec, &rear_right_output,
-  &rear_right_velocity_setpoint);
+//  PID controllers for the left and right drivetrain sides
+QuickPID left_side_pid(&current_left_side_rads_sec, &left_side_output,
+  &left_side_velocity_setpoint);
+QuickPID right_side_pid(&current_right_side_rads_sec, &right_side_output,
+  &right_side_velocity_setpoint);
 
 /**
  * @brief Function to setup the PID controllers
  */
 void setup_pid()
 {
-  rear_left_pid.SetOutputLimits(-127.0, 127.0);
-  rear_right_pid.SetOutputLimits(-127.0, 127.0);
+  left_side_pid.SetOutputLimits(-127.0, 127.0);
+  right_side_pid.SetOutputLimits(-127.0, 127.0);
 
-  rear_left_pid.SetTunings(8.0, 0.7, 0.00);
-  rear_right_pid.SetTunings(8.0, 0.7, 0.00);
+  left_side_pid.SetTunings(8.0, 0.7, 0.00);
+  right_side_pid.SetTunings(8.0, 0.7, 0.00);
 
-  rear_left_pid.SetSampleTimeUs(50000);
-  rear_right_pid.SetSampleTimeUs(50000);
+  left_side_pid.SetSampleTimeUs(50000);
+  right_side_pid.SetSampleTimeUs(50000);
 
-  rear_left_pid.SetMode(QuickPID::Control::automatic);
-  rear_right_pid.SetMode(QuickPID::Control::automatic);
+  left_side_pid.SetMode(QuickPID::Control::automatic);
+  right_side_pid.SetMode(QuickPID::Control::automatic);
 }
 
 void mark_motor_command_received()
@@ -76,12 +77,12 @@ void mark_motor_command_received()
 
 void stop_motors()
 {
-  rear_left_velocity_setpoint = 0.0;
-  rear_right_velocity_setpoint = 0.0;
-  rear_left_output = 0.0;
-  rear_right_output = 0.0;
-  rear_left_pid.Reset();
-  rear_right_pid.Reset();
+  left_side_velocity_setpoint = 0.0;
+  right_side_velocity_setpoint = 0.0;
+  left_side_output = 0.0;
+  right_side_output = 0.0;
+  left_side_pid.Reset();
+  right_side_pid.Reset();
   send_sabertooth_command(Serial2, SABERTOOTH_ADDR, 1, 0);
   send_sabertooth_command(Serial2, SABERTOOTH_ADDR, 2, 0);
 }
@@ -134,44 +135,48 @@ void update_motors()
     stop_motors();
     return;
   }
-  if (abs(rear_left_velocity_setpoint) <= SETPOINT_DEADBAND_RAD_S &&
-    abs(rear_right_velocity_setpoint) <= SETPOINT_DEADBAND_RAD_S)
+  if (abs(left_side_velocity_setpoint) <= SETPOINT_DEADBAND_RAD_S &&
+    abs(right_side_velocity_setpoint) <= SETPOINT_DEADBAND_RAD_S)
   {
     stop_motors();
     return;
   }
 
   //  Compute the PID output for both motors.
-  rear_left_pid.Compute();
-  rear_right_pid.Compute();
+  left_side_pid.Compute();
+  right_side_pid.Compute();
 
   if (SERIAL_DEBUG) {
-    Serial.print("RL setpoint: ");
-    Serial.print(rear_left_velocity_setpoint);
+    Serial.print("Left setpoint: ");
+    Serial.print(left_side_velocity_setpoint);
     Serial.print(" measured: ");
-    Serial.print(current_rear_left_rads_sec);
+    Serial.print(current_left_side_rads_sec);
     Serial.print(" output: ");
-    Serial.print(rear_left_output);
-    Serial.print(" | RR setpoint: ");
-    Serial.print(rear_right_velocity_setpoint);
+    Serial.print(left_side_output);
+    Serial.print(" | Right setpoint: ");
+    Serial.print(right_side_velocity_setpoint);
     Serial.print(" measured: ");
-    Serial.print(current_rear_right_rads_sec);
+    Serial.print(current_right_side_rads_sec);
     Serial.print(" output: ");
-    Serial.println(rear_right_output);
+    Serial.println(right_side_output);
   }
 
-  const int rear_left_command = command_with_feedforward(
-      rear_left_output, rear_left_velocity_setpoint, LEFT_FEEDFORWARD_COMMAND);
-  const int rear_right_command = -command_with_feedforward(
-      rear_right_output, rear_right_velocity_setpoint, RIGHT_FEEDFORWARD_COMMAND);
+  const int left_side_command = constrain(
+      command_with_feedforward(
+        left_side_output, left_side_velocity_setpoint, LEFT_FEEDFORWARD_COMMAND),
+      -DEBUG_MAX_MOTOR_COMMAND, DEBUG_MAX_MOTOR_COMMAND);
+  const int right_side_command = constrain(
+      -command_with_feedforward(
+        right_side_output, right_side_velocity_setpoint, RIGHT_FEEDFORWARD_COMMAND),
+      -DEBUG_MAX_MOTOR_COMMAND, DEBUG_MAX_MOTOR_COMMAND);
 
   if (SERIAL_DEBUG) {
-    Serial.print(" commands: RL=");
-    Serial.print(rear_left_command);
-    Serial.print(" RR=");
-    Serial.println(rear_right_command);
+    Serial.print(" commands: left=");
+    Serial.print(left_side_command);
+    Serial.print(" right=");
+    Serial.println(right_side_command);
   }
 
-  send_sabertooth_command(Serial2, SABERTOOTH_ADDR, 1, rear_right_command);
-  send_sabertooth_command(Serial2, SABERTOOTH_ADDR, 2, rear_left_command);
+  send_sabertooth_command(Serial2, SABERTOOTH_ADDR, 1, right_side_command);
+  send_sabertooth_command(Serial2, SABERTOOTH_ADDR, 2, left_side_command);
 }

--- a/micro_ros_platform_firmware/platform/motor_control.hpp
+++ b/micro_ros_platform_firmware/platform/motor_control.hpp
@@ -27,17 +27,17 @@ constexpr float ENCODER_COUNTS_PER_MOTOR_REV = 48.0;
 constexpr float GEAR_RATIO_MULTIPLIER = 51.0;
 
 // Control variables
-extern float rear_left_velocity_setpoint;
-extern float rear_right_velocity_setpoint;
-extern float rear_left_output;
-extern float rear_right_output;
+extern float left_side_velocity_setpoint;
+extern float right_side_velocity_setpoint;
+extern float left_side_output;
+extern float right_side_output;
 extern unsigned long last_motor_command_ms;
-extern QuickPID rear_left_pid;
-extern QuickPID rear_right_pid;
+extern QuickPID left_side_pid;
+extern QuickPID right_side_pid;
 
 // ROS-shared velocity measurements
-extern float current_rear_left_rads_sec;
-extern float current_rear_right_rads_sec;
+extern float current_left_side_rads_sec;
+extern float current_right_side_rads_sec;
 
 void setup_pid();
 void mark_motor_command_received();

--- a/micro_ros_platform_firmware/platform/msg_utils.cpp
+++ b/micro_ros_platform_firmware/platform/msg_utils.cpp
@@ -137,12 +137,12 @@ void publish_debug_message()
   const int written = snprintf(
       debug_message_buffer, DEBUG_MESSAGE_LEN,
       "ros=%s battery_critical=%s battery_v=%.2f last_cmd_age_ms=%ld "
-      "setpoints_rl=%.3f setpoints_rr=%.3f measured_rl=%.3f measured_rr=%.3f "
-      "output_rl=%.2f output_rr=%.2f",
+      "setpoint_left=%.3f setpoint_right=%.3f measured_left=%.3f measured_right=%.3f "
+      "output_left=%.2f output_right=%.2f",
       ros_is_connected() ? "connected" : "waiting", battery_is_critical() ? "true" : "false",
-      read_battery_voltage(), last_cmd_age_ms, rear_left_velocity_setpoint,
-      rear_right_velocity_setpoint, current_rear_left_rads_sec, current_rear_right_rads_sec,
-      rear_left_output, rear_right_output);
+      read_battery_voltage(), last_cmd_age_ms, left_side_velocity_setpoint,
+      right_side_velocity_setpoint, current_left_side_rads_sec, current_right_side_rads_sec,
+      left_side_output, right_side_output);
 
   if (written < 0) {
     return;
@@ -159,20 +159,20 @@ void publish_debug_message()
  * @brief Publish the JointState message with current velocity data.
  *
  * This function updates the velocity data in the JointState message with the
- * current velocities of the rear left and rear right motors, then publishes
+ * current velocities of the left and right drivetrain sides, then publishes
  * the message.
  */
 void publish_joint_state_message()
 {
-  feedback_msg.position.data[0] = current_rear_left_position_rad;
-  feedback_msg.position.data[1] = current_rear_right_position_rad;
-  feedback_msg.position.data[2] = current_rear_left_position_rad;
-  feedback_msg.position.data[3] = current_rear_right_position_rad;
+  feedback_msg.position.data[0] = current_left_side_position_rad;
+  feedback_msg.position.data[1] = current_right_side_position_rad;
+  feedback_msg.position.data[2] = current_left_side_position_rad;
+  feedback_msg.position.data[3] = current_right_side_position_rad;
 
-  feedback_msg.velocity.data[0] = current_rear_left_rads_sec;
-  feedback_msg.velocity.data[1] = current_rear_right_rads_sec;
-  feedback_msg.velocity.data[2] = current_rear_left_rads_sec;
-  feedback_msg.velocity.data[3] = current_rear_right_rads_sec;
+  feedback_msg.velocity.data[0] = current_left_side_rads_sec;
+  feedback_msg.velocity.data[1] = current_right_side_rads_sec;
+  feedback_msg.velocity.data[2] = current_left_side_rads_sec;
+  feedback_msg.velocity.data[3] = current_right_side_rads_sec;
   RCSOFTCHECK(rcl_publish(&feedback_publisher, &feedback_msg, NULL));
 }
 
@@ -181,7 +181,7 @@ void publish_joint_state_message()
  *
  * This function processes incoming JointState messages, extracting the joint
  * names and their corresponding velocity setpoints. It updates the global
- * velocity setpoints for the rear left and rear right motors based on the
+ * velocity setpoints for the left and right drivetrain sides based on the
  * received message.
  *
  * @param msgin Pointer to the incoming JointState message.
@@ -206,16 +206,16 @@ void subscription_callback(const void * msgin)
     const char * name = joint_msg->name.data[i].data;
     float velocity = joint_msg->velocity.data[i];
     if (strcmp(name, "front_left_joint") == 0) {
-      rear_left_velocity_setpoint = velocity;
+      left_side_velocity_setpoint = velocity;
       received_motor_command = true;
     } else if (strcmp(name, "front_right_joint") == 0) {
-      rear_right_velocity_setpoint = velocity;
+      right_side_velocity_setpoint = velocity;
       received_motor_command = true;
     } else if (strcmp(name, "rear_left_joint") == 0) {
-      rear_left_velocity_setpoint = velocity;
+      left_side_velocity_setpoint = velocity;
       received_motor_command = true;
     } else if (strcmp(name, "rear_right_joint") == 0) {
-      rear_right_velocity_setpoint = velocity;
+      right_side_velocity_setpoint = velocity;
       received_motor_command = true;
     }
   }
@@ -224,7 +224,7 @@ void subscription_callback(const void * msgin)
     mark_motor_command_received();
   }
 
-  if (abs(rear_left_velocity_setpoint) <= 0.05 && abs(rear_right_velocity_setpoint) <= 0.05) {
+  if (abs(left_side_velocity_setpoint) <= 0.05 && abs(right_side_velocity_setpoint) <= 0.05) {
     stop_motors();
   }
 }

--- a/micro_ros_platform_firmware/platform/platform.ino
+++ b/micro_ros_platform_firmware/platform/platform.ino
@@ -71,14 +71,14 @@ namespace
       return;
     }
 
-    rear_left_velocity_setpoint = left;
-    rear_right_velocity_setpoint = right;
+    left_side_velocity_setpoint = left;
+    right_side_velocity_setpoint = right;
     mark_motor_command_received();
 
     Serial.print("Setpoints: left=");
-    Serial.print(rear_left_velocity_setpoint, 3);
+    Serial.print(left_side_velocity_setpoint, 3);
     Serial.print(" rad/s, right=");
-    Serial.print(rear_right_velocity_setpoint, 3);
+    Serial.print(right_side_velocity_setpoint, 3);
     Serial.println(" rad/s");
   }
 
@@ -152,10 +152,10 @@ void loop()
       Serial.print(battery_is_critical() ? "true" : "false");
       Serial.print(" last_cmd_age_ms=");
       Serial.print(last_motor_command_ms == 0 ? -1 : static_cast<long>(now - last_motor_command_ms));
-      Serial.print(" setpoints RL=");
-      Serial.print(rear_left_velocity_setpoint, 3);
-      Serial.print(" RR=");
-      Serial.println(rear_right_velocity_setpoint, 3);
+      Serial.print(" setpoints left=");
+      Serial.print(left_side_velocity_setpoint, 3);
+      Serial.print(" right=");
+      Serial.println(right_side_velocity_setpoint, 3);
     }
   }
 


### PR DESCRIPTION
## Summary

Refactors the Teensy platform firmware terminology from rear-left/rear-right motor control to left-side/right-side drivetrain control.

The rover drivetrain now treats each side as a paired motor channel, with the front encoders used as side feedback. This makes the firmware naming match the actual hardware layout more closely and reduces confusion while debugging motor direction, encoder feedback, and PID behavior.

## Changes

- Renamed internal firmware control variables from `rear_left` / `rear_right` to `left_side` / `right_side`
- Updated encoder feedback variables and debug output to use left/right side terminology
- Kept ROS joint names unchanged:
  - `front_left_joint`
  - `front_right_joint`
  - `rear_left_joint`
  - `rear_right_joint`
- Continued mapping both left joints to the left side setpoint and both right joints to the right side setpoint
- Updated debug messages to report:
  - `setpoint_left`
  - `setpoint_right`
  - `measured_left`
  - `measured_right`
  - `output_left`
  - `output_right`
- Preserved the current Sabertooth side mapping and motor polarity tuning
- Left the temporary motor command cap in place while validating post-rewire behavior

## Validation

- Confirmed both drivetrain sides now produce sane encoder feedback under command
- Verified side feedback no longer reports impossible encoder counts after moving back to front encoder feedback
- Observed stable closed-loop behavior with a `3.0 / 3.0 rad/s` command:
  - left side measured around `2.7-2.8 rad/s`
  - right side measured around `2.6 rad/s`
  - command outputs remained stable rather than running away

## Notes

This is primarily a naming and clarity refactor, but it captures the current hardware model more accurately: two Sabertooth-controlled drivetrain sides, each represented by one encoder feedback source.