### PR TITLE
Adjusts the IMU yaw

### DIFF
--- a/rugged_rover_robot_description/urdf/rugged_rover.urdf.xacro
+++ b/rugged_rover_robot_description/urdf/rugged_rover.urdf.xacro
@@ -177,7 +177,7 @@
   <joint name="base_to_imu" type="fixed">
     <parent link="base_link"/>
     <child link="imu_link"/>
-    <origin xyz="0.015 0.070 0.010" rpy="3.14159265359 0 1.57079632679"/>
+    <origin xyz="0.015 0.070 0.010" rpy="3.14159265359 0 -1.57079632679"/>
   </joint>
 
   <ros2_control name="RuggedRoverControl" type="system">


### PR DESCRIPTION
## Summary

Adjusts the IMU yaw mounting transform to match the current physical orientation on the rover.

## Changes

- Updates the IMU fixed joint rotation to account for the sensor being rotated 180 degrees around the Z axis
- Keeps the IMU frame aligned with the rover’s actual installed orientation
- Improves consistency between IMU yaw data, wheel odometry, EKF output, and RViz visualization

## Validation

- Confirmed the IMU is physically mounted with an additional 180 degree yaw rotation
- Verified the URDF transform now reflects the installed orientation
- Intended to reduce yaw sign/alignment issues when fusing IMU data with wheel odometry

## Notes

This is a small calibration/update PR for the robot description only. No runtime logic changes are included.